### PR TITLE
Remove signTransaction from Solana signAndSend

### DIFF
--- a/packages/wallets/solana/src/solana.ts
+++ b/packages/wallets/solana/src/solana.ts
@@ -210,13 +210,7 @@ export class SolanaWallet extends Wallet<
   async signAndSendTransaction(
     params: SolanaSignAndSendTransactionParams
   ): Promise<SendTransactionResult<SolanaSubmitTransactionResult>> {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const signed = await this.signTransaction(params.transaction);
-    return this.sendTransaction({
-      ...params,
-      transaction: signed,
-    });
+    return this.sendTransaction(params);
   }
 
   signMessage(msg: SolanaMessage): Promise<Signature> {


### PR DESCRIPTION
Since the `sendTransaction` function from the Solana Wallet Adapter does both signing and sending the transaction, the `signTransaction` is not needed - it triggers the confirmation window twice.