### PR TITLE
add property to inform if wallets are in detection process for the async cases

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xlabs-libs/wallet-aggregator-react",
   "repository": "https://github.com/XLabs/wallet-aggregator-sdk/tree/master/packages/react",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react/src/context/WalletContext.tsx
+++ b/packages/react/src/context/WalletContext.tsx
@@ -23,6 +23,7 @@ interface IWalletContext {
   wallets: WalletMap;
   defaultWallet?: Wallet | undefined;
   availableWallets: AvailableWalletsMap;
+  isDetectingWallets: boolean;
   changeWallet: (newWallet: Wallet) => void;
   unsetWalletFromChain: (chainId: ChainId) => void;
   coalesceChainId: (chainId: ChainId) => ChainId;
@@ -34,6 +35,7 @@ export const WalletContext = createContext<IWalletContext>({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   unsetWalletFromChain: () => {},
   availableWallets: {},
+  isDetectingWallets: false,
   wallets: {},
   coalesceChainId: (chainId: ChainId) => chainId,
 });
@@ -60,6 +62,7 @@ export const WalletContextProvider = ({
   coalesceTerraChains = true,
 }: React.PropsWithChildren<IWalletContextProviderProps>) => {
   const [wallets, setWallets] = useState<WalletMap>({});
+  const [isDetectingWallets, setDetectingWallets] = useState(false);
   const [availableWallets, setAvailableWallets] = useState<AvailableWalletsMap>(
     {}
   );
@@ -86,12 +89,13 @@ export const WalletContextProvider = ({
         typeof configureWallets === "function"
           ? await configureWallets()
           : configureWallets;
-
       setAvailableWallets(available);
+      setDetectingWallets(false);
     };
 
     // TODO: maybe handle init errors by providing a flag/message to child components
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setDetectingWallets(true);
     initWallets();
   }, [configureWallets]);
 
@@ -137,6 +141,7 @@ export const WalletContextProvider = ({
       wallets,
       defaultWallet,
       availableWallets,
+      isDetectingWallets,
       changeWallet,
       unsetWalletFromChain,
       coalesceChainId,
@@ -145,6 +150,7 @@ export const WalletContextProvider = ({
       wallets,
       defaultWallet,
       availableWallets,
+      isDetectingWallets,
       unsetWalletFromChain,
       coalesceChainId,
     ]

--- a/packages/react/src/context/hooks.ts
+++ b/packages/react/src/context/hooks.ts
@@ -60,6 +60,23 @@ export const useWalletsForChain = (chainId?: ChainId): Wallet[] => {
 };
 
 /**
+ * Retrieve the list of available wallets for a specific chain, computed from the available wallets configured for the context
+ * @param chainId A chain id
+ * @returns An object with a wallets property and isDetectingWallets, where isDetectingWallets switch between true and false
+ * and wallets is a non-empty array of Wallet objects, or an empty array if no entry has been found for that chain id
+ */
+export const useWalletsForChainWithStatus = (
+  chainId?: ChainId
+): { wallets: Wallet[]; isDetectingWallets: boolean } => {
+  const wallets = useWalletsForChain(chainId);
+  const { isDetectingWallets } = useWalletContext();
+  return useMemo(
+    () => ({ wallets, isDetectingWallets }),
+    [wallets, isDetectingWallets]
+  );
+};
+
+/**
  * Returns a function that takes a `Wallet` as an argument and selects it as the current wallet for its chain (as indicated by the wallet's `getChainId`) and replacing the previous, should there be one. The selected wallet can then be retrieved through the useWallet and useWalletFromChain hooks
  *
  * The returned function does not attempt to connect the selected wallet, nor disconnect the replaced wallet.


### PR DESCRIPTION
add property to inform and detect the change between detecting wallets and wallets detected, so, the users could provide a better information to end users on async configs