### PR TITLE
Solana: bump dependencies' versions

### DIFF
--- a/packages/wallets/solana/README.md
+++ b/packages/wallets/solana/README.md
@@ -12,7 +12,10 @@ import {
   SolflareWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
 import { clusterApiUrl } from "@solana/web3.js";
-import { SolanaWallet } from "@xlabs-libs/wallet-aggregator-solana";
+import {
+  getSolanaStandardWallets,
+  SolanaWallet,
+} from "@xlabs-libs/wallet-aggregator-solana";
 
 const cluster = "mainnet";
 const url = clusterApiUrl("mainnet-beta");
@@ -21,8 +24,14 @@ const connection = new Connection(url);
 
 const martian = new SolanaWallet(new PhantomWalletAdapter(), connection);
 
-const solanaWallets: SolanaWallet[] = [
+// get those wallets that support the wallet standard
+const standardWallets = getSolanaStandardWallets(connection);
+
+// create wallets using the adapters
+const adapterWallets = [
   new PhantomWalletAdapter(),
   new SolflareWalletAdapter(),
 ].map((adapter) => new SolanaWallet(adapter, connection));
+
+const solanaWallets: SolanaWallet[] = [...standardWallets, ...adapters];
 ```

--- a/packages/wallets/solana/package.json
+++ b/packages/wallets/solana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xlabs-libs/wallet-aggregator-solana",
   "repository": "https://github.com/XLabs/wallet-aggregator-sdk/tree/master/packages/wallets/solana",
-  "version": "0.0.1-alpha.13",
+  "version": "0.0.1-alpha.14",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -23,14 +23,16 @@
     "src/"
   ],
   "devDependencies": {
-    "@solana/web3.js": "^1.70.1",
+    "@solana/web3.js": "^1.87.6",
     "@types/node": "^18.11.9",
     "@types/node-fetch": "^2.6.2",
     "shx": "^0.3.4",
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@solana/wallet-adapter-base": "^0.9.20",
+    "@solana/wallet-adapter-base": "^0.9.23",
+    "@solana/wallet-standard-wallet-adapter-base": "^1.1.1",
+    "@wallet-standard/app": "^1.0.1",
     "@xlabs-libs/wallet-aggregator-core": "workspace:^"
   }
 }

--- a/packages/wallets/solana/src/index.ts
+++ b/packages/wallets/solana/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./solana";
+export * from "./utils";

--- a/packages/wallets/solana/src/utils.ts
+++ b/packages/wallets/solana/src/utils.ts
@@ -1,0 +1,23 @@
+import { isWalletAdapterCompatibleStandardWallet } from "@solana/wallet-adapter-base";
+import { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { Connection } from "@solana/web3.js";
+import { getWallets } from "@wallet-standard/app";
+import { SolanaWallet } from "./solana";
+
+/**
+ * Detect wallets that are compatible with the standard wallet interface
+ *
+ * @returns A list of SolanaWallet instances
+ */
+export function getSolanaStandardWallets(
+  connection: Connection
+): SolanaWallet[] {
+  // from https://github.com/solana-labs/wallet-standard/blob/c68c26604e0b9624e924292e243df44c742d1c00/packages/wallet-adapter/react/src/useStandardWalletAdapters.ts#L78
+  return getWallets()
+    .get()
+    .filter(isWalletAdapterCompatibleStandardWallet)
+    .map(
+      (wallet) =>
+        new SolanaWallet(new StandardWalletAdapter({ wallet }), connection)
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,7 +320,7 @@ importers:
         version: 1.14.4
       '@injectivelabs/wallet-ts':
         specifier: 1.14.4
-        version: 1.14.4(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1)(bs58@4.0.1)(google-protobuf@3.21.2)(react-dom@18.2.0)(react@18.2.0)
+        version: 1.14.4(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6)(bs58@4.0.1)(google-protobuf@3.21.2)(react-dom@18.2.0)(react@18.2.0)
       '@xlabs-libs/wallet-aggregator-core':
         specifier: workspace:^
         version: link:../core
@@ -412,15 +412,21 @@ importers:
   packages/wallets/solana:
     dependencies:
       '@solana/wallet-adapter-base':
-        specifier: ^0.9.20
-        version: 0.9.20(@solana/web3.js@1.70.1)
+        specifier: ^0.9.23
+        version: 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/wallet-standard-wallet-adapter-base':
+        specifier: ^1.1.1
+        version: 1.1.1(@solana/web3.js@1.87.6)(bs58@4.0.1)
+      '@wallet-standard/app':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@xlabs-libs/wallet-aggregator-core':
         specifier: workspace:^
         version: link:../core
     devDependencies:
       '@solana/web3.js':
-        specifier: ^1.70.1
-        version: 1.70.1
+        specifier: ^1.87.6
+        version: 1.87.6
       '@types/node':
         specifier: ^18.11.9
         version: 18.11.11
@@ -801,12 +807,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+    dev: false
 
   /@babel/runtime@7.20.6:
     resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
+    dev: false
+
+  /@babel/runtime@7.23.7:
+    resolution: {integrity: sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -870,12 +884,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@blocto/sdk@0.2.22(@solana/web3.js@1.70.1):
+  /@blocto/sdk@0.2.22(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-Ro1AiISSlOiri/It932NEFxnDuF83Ide+z0p3KHs5+CdYYLYgCMmyroQnfRtoh3mbXdrTvI+EAuSkr+meWNqrg==}
     peerDependencies:
       '@solana/web3.js': ^1.30.2
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       buffer: 6.0.3
       eip1193-provider: 1.0.1
@@ -911,7 +925,7 @@ packages:
   /@censo-custody/solana-wallet-adapter@0.1.0:
     resolution: {integrity: sha512-iM1jFVzBMfk7iokgUVfA2xvGUegixklUISgMARa/VA2mFIjoi32t4xmD8PtWHht81fmg107aYhLnTV1cM7NkAg==}
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       eventemitter3: 4.0.7
       uuid: 8.3.2
@@ -944,7 +958,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@metamask/safe-event-emitter': 2.0.0
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bind-decorator: 1.0.11
       bn.js: 5.2.1
       buffer: 6.0.3
@@ -1946,11 +1960,11 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@fractalwagmi/solana-wallet-adapter@0.1.1(@solana/web3.js@1.70.1)(react-dom@18.2.0)(react@18.2.0):
+  /@fractalwagmi/solana-wallet-adapter@0.1.1(@solana/web3.js@1.87.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-oTZLEuD+zLKXyhZC5tDRMPKPj8iaxKLxXiCjqRfOo4xmSbS2izGRWLJbKMYYsJysn/OI3UJ3P6CWP8WUWi0dZg==}
     dependencies:
       '@fractalwagmi/popup-connection': 1.0.18(react-dom@18.2.0)(react@18.2.0)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
       bs58: 5.0.0
     transitivePeerDependencies:
       - '@solana/web3.js'
@@ -2373,7 +2387,7 @@ packages:
       - google-protobuf
     dev: false
 
-  /@injectivelabs/wallet-ts@1.14.4(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1)(bs58@4.0.1)(google-protobuf@3.21.2)(react-dom@18.2.0)(react@18.2.0):
+  /@injectivelabs/wallet-ts@1.14.4(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6)(bs58@4.0.1)(google-protobuf@3.21.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-v5fDmAteUPWFA+1GurTwBGPD4VmAr/et/dsXP8rNtG4Xkpx1Oe9cuybvGce6udi4+RIM9mK2vjiOGAx5Er55bQ==}
     requiresBuild: true
     dependencies:
@@ -2395,8 +2409,8 @@ packages:
       '@ledgerhq/hw-transport-webhid': 6.27.14
       '@ledgerhq/hw-transport-webusb': 6.27.14
       '@metamask/eth-sig-util': 4.0.1
-      '@solana/wallet-adapter-wallets': 0.19.10(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1)(bs58@4.0.1)(react-dom@18.2.0)(react@18.2.0)
-      '@toruslabs/torus-embed': 1.41.2(@babel/runtime@7.20.13)
+      '@solana/wallet-adapter-wallets': 0.19.10(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6)(bs58@4.0.1)(react-dom@18.2.0)(react@18.2.0)
+      '@toruslabs/torus-embed': 1.41.2(@babel/runtime@7.23.7)
       '@trezor/connect-web': 9.0.8
       alchemy-sdk: 2.8.1
       eip1193-provider: 1.0.1
@@ -2431,12 +2445,12 @@ packages:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
     dev: false
 
-  /@jnwng/walletconnect-solana@0.1.4(@solana/web3.js@1.70.1):
+  /@jnwng/walletconnect-solana@0.1.4(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-tdVMeH9IlLHV7SxG81oD+HXmYEs/FR8D19BQJpE+7qsus4kO0yn9y/kQ3m6wsdHQr22L5KL10VDIKSWQ+8pyJg==}
     peerDependencies:
       '@solana/web3.js': ^1.52.0
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       '@walletconnect/qrcode-modal': 1.8.0
       '@walletconnect/sign-client': 2.0.0-rc.3
       '@walletconnect/utils': 2.0.0-rc.3
@@ -2615,7 +2629,7 @@ packages:
       '@keystonehq/bc-ur-registry': 0.5.4
       '@keystonehq/bc-ur-registry-sol': 0.3.1
       '@keystonehq/sdk': 0.13.1
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 5.0.0
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -3096,10 +3110,6 @@ packages:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
     dependencies:
       '@noble/hashes': 1.3.2
-    dev: false
-
-  /@noble/ed25519@1.7.1:
-    resolution: {integrity: sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==}
 
   /@noble/hashes@1.1.3:
     resolution: {integrity: sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==}
@@ -3114,9 +3124,6 @@ packages:
   /@noble/hashes@1.3.2:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
-
-  /@noble/secp256k1@1.7.0:
-    resolution: {integrity: sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==}
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3257,6 +3264,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -3318,14 +3326,14 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@particle-network/solana-wallet@0.5.6(@solana/web3.js@1.70.1)(bs58@4.0.1):
+  /@particle-network/solana-wallet@0.5.6(@solana/web3.js@1.87.6)(bs58@4.0.1):
     resolution: {integrity: sha512-Ad0hwJsWRCbptp+mmLFsbrERDQbW+QhFQOmWRT8+6gGrY6qNTApwI9+jlpkxOzEI9rvSqFD1qKKMlqy1n+fJNA==}
     peerDependencies:
       '@solana/web3.js': ^1.50.1
       bs58: ^4.0.1
     dependencies:
       '@particle-network/auth': 0.5.6
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
     dev: false
 
@@ -3350,24 +3358,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@project-serum/sol-wallet-adapter@0.2.0(@solana/web3.js@1.70.1):
+  /@project-serum/sol-wallet-adapter@0.2.0(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-ed7wZwlDqjF88VCq7eHVO8njHqdUkBxBL8WEVOnB47ooLO4btOJt6GBdkKpKqKX86c86LiEROJclcdW8e7kIjg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.5.0
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       eventemitter3: 4.0.7
     dev: false
 
-  /@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.70.1):
+  /@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.5.0
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       eventemitter3: 4.0.7
     dev: false
@@ -3549,95 +3557,98 @@ packages:
     dependencies:
       buffer: 6.0.3
 
-  /@solana/wallet-adapter-alpha@0.1.7(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-alpha@0.1.7(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-Eu/De+bhfPBiADLdpmAfJu7yKezEzDYnKjCVWtJW3oo9WbAO/Xd30Pg4bXbxvKMXdrYWRFZx3uQQruojnL+a+A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-avana@0.1.10(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-avana@0.1.10(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-s+McAL96/9cfGh5/z1hjCrCpsQ971PJmpxiXhwPdOwnkPT/40wIkfSY7RKZjiKlENoXfpAcj64K1d8xu+lUCEw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-backpack@0.1.11(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-backpack@0.1.11(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-acICFuFYzAQ5gBesHF0sykfFZ8dZurBwYuIXbF4kYDYu6tDpZeUG0eRY+7fxcNDR0J3ezPkxaNgyoibhIN6y5A==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-base@0.9.20(@solana/web3.js@1.70.1):
-    resolution: {integrity: sha512-ZvnhJ4EJk61oyuBH/a9tMpUfeWQ3g3Cc0Nzl1NzE4SdqEhiNoEW8HXDig9HMemZ9bIEUxIpPWxp+SwjVl0u+rg==}
+  /@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.87.6):
+    resolution: {integrity: sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@solana/web3.js': ^1.58.0
+      '@solana/web3.js': ^1.77.3
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-standard-features': 1.1.0
+      '@solana/web3.js': 1.87.6
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
       eventemitter3: 4.0.7
     dev: false
 
-  /@solana/wallet-adapter-bitkeep@0.3.16(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-bitkeep@0.3.16(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-I79ZGmxVZX70K+5Nscukl0Qc9LRNvrki1KHA3dl17zl8xwQKoVrMksS8Y2WK1OGrrIRZLPhRXxYMgcX2E8TYIA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-bitpie@0.5.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-bitpie@0.5.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-7qcuz0eiePAkeAiOF5hGLeRLqGwJZ6sdKk5+IuEQ92YQulurhWg8uQPO5sJpRNS2Bwf1sp1dh05eoCx5KvGLqw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-blocto@0.5.19(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-blocto@0.5.19(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-UgY8Kbsv29DoDS4nngCwCYSLQbpb7bIvmT4bMy3muOukzgMP97dV18FoABFXGV4te6/fFrDwSisJffO1WrahXA==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@blocto/sdk': 0.2.22(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@blocto/sdk': 0.2.22(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - bufferutil
       - debug
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-brave@0.1.14(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-brave@0.1.14(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-dKfh8ySglr5CpzOilciUR3FUhnzed/9K3Nwo6w7HV3GK24Z1q3CpPRDlbw8OoB8Pw+4GGcMCmFlDN4PMhZcyWw==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-censo@0.1.1(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-censo@0.1.1(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-gPY3UauwBE0MRhhayrvANaHxMhSj5/IqHBabxgXqXXA9SRwcdxaPEdHWclB91noocgHZqZI0T9+iF211NXrQ2g==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -3645,137 +3656,137 @@ packages:
       '@solana/web3.js': ^1.61.0
     dependencies:
       '@censo-custody/solana-wallet-adapter': 0.1.0
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-clover@0.4.16(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-clover@0.4.16(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-5YVZVetfQedbRUCEpzqfG/HiOqn/7cFSyWI319BIvPPBc2YAK5Wtv/ILeJOnj3MjBp8B/WlASORhxyDgQJQrMg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-coin98@0.5.17(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-coin98@0.5.17(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-CRGt2Aza9tt59vgtKscJbNSoT3fRYAxsj5QZk0Tb64THMP5o+t93LUT09cCYoOt15MlKWW5pr93Yx+J0Ok0dOg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
     dev: false
 
-  /@solana/wallet-adapter-coinbase@0.1.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-coinbase@0.1.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-Rcz0TqXKx0yvTrbWp9647yKpkFugNp48PQ1kpnMIsH0amcmHMLm2tE6qJ/B36EXY/7gmlW/tdnV7HO/ToS0UXA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-coinhub@0.3.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-coinhub@0.3.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-ReOUkQsoDTCG97BHuF38nHOFwab50yRvLlft5qec2dv7AQ5Y5RfcIAEe66D2z2mCc1yHAUwfzVNsMXaFsswjfA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-exodus@0.1.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-exodus@0.1.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-dfTRlw7FeF2lYOE6v9Ubzs6A++/EN96nYNg5AxcEycidQ/kEJBWp7LeKrvXGj2+Ivl+uia5SCF7DfHdm5BQXdg==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-fractal@0.1.5(@solana/web3.js@1.70.1)(react-dom@18.2.0)(react@18.2.0):
+  /@solana/wallet-adapter-fractal@0.1.5(@solana/web3.js@1.87.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JkkhLoLP5gnfS/MiJVVsE3VTvaCJFm3m6nD7Umy+Imj69P4N/60eRfwjFKe/hf8eLw6LEuYYkAQp1FFMQCOFoA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@fractalwagmi/solana-wallet-adapter': 0.1.1(@solana/web3.js@1.70.1)(react-dom@18.2.0)(react@18.2.0)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@fractalwagmi/solana-wallet-adapter': 0.1.1(@solana/web3.js@1.87.6)(react-dom@18.2.0)(react@18.2.0)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - react
       - react-dom
     dev: false
 
-  /@solana/wallet-adapter-glow@0.1.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-glow@0.1.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-25xsdUntZQFsboVLxYFMer3ujXshHfOkvpAA6a+A9m7uNlqT6ejHqT75qqluAkxq98DzaZ8tEbFtlU7hfFgdBQ==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-huobi@0.1.12(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-huobi@0.1.12(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-YF/AJfkm76nk0OTLM3iNdiIdk2nZzWW/354XQB3om+p+m7jN9CXY9VG38Ov36OmF9s+KEGdsE1ng8AU8cBiGMg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-hyperpay@0.1.11(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-hyperpay@0.1.11(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-22mHfxgDjMbKZO932Cz267mre6Y8/x/x8RqLb6YGTKr/JLiLqWcC9lqC1CkhHW37X3p5s+RFDG44L7Yhg+pmBw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-keystone@0.1.9(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-keystone@0.1.9(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-EoTLhgyNCqe3W2RoccIxRBf1q1BWH0WI40zzy5OYqxeOpPiWlCAIbLKx6F+TeXrIzrJvYLKfyYI0E27bwaMyOw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
       '@keystonehq/sol-keyring': 0.3.1
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-krystal@0.1.9(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-krystal@0.1.9(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-Cgfh8ixgmwcnQE0L9yeNow6KWbG2/VIcQRbldRDqhg3jzMbhNjjoEJQ0wNh0ypllnM75Dgvb4y5+q+ZFzCpp3g==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-ledger@0.9.22(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-ledger@0.9.22(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-Fjm51PfB/vKMsn5FNeTc+So+BTOVSbRIIOZAnJ/vlp5OZRUNuffDQijVprl+91ZCaeyVitikjKrpP1IjB7paOw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3784,200 +3795,200 @@ packages:
       '@ledgerhq/devices': 6.27.1
       '@ledgerhq/hw-transport': 6.27.1
       '@ledgerhq/hw-transport-webhid': 6.27.1
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       buffer: 6.0.3
     dev: false
 
-  /@solana/wallet-adapter-magiceden@0.1.10(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-magiceden@0.1.10(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-UUo8YK+nkZlILvxSEWQEjmyBPJmeIhNc/TTIR+pbpBipeSGPiHiuKOkPQbYTZYwMDsHuFpoCQgXhBAzyZiTwrw==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-mathwallet@0.9.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-mathwallet@0.9.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-xac6zbXwTkabP+YK0R8REoDOb+DVWyd2B2CJ7Y82eSJdEbpbXB0qn/5B/xS5jikN1kYdJjgKHjnlC2blMD8M0Q==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-neko@0.2.9(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-neko@0.2.9(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-xY7MMuIwE18G68mjOLPYvZb3DWdVW6MOX7LUZLblOtan0BPZ9aa6CBToneww5JhAlM134jJGqihLqCJWU6IHnA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-nightly@0.1.12(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-nightly@0.1.12(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-UuKMcZKzTmKJflBiVyoRPN4QD2qjxpVv5QZBWKgp3TdbAkWOTlOOlyqg0LueEv1Q5S2hBgy8p1D7fVXN4mpaXw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-nufi@0.1.13(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-nufi@0.1.13(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-4CtyFlMweZJVgJ/u7FWccKJDvzEzoYtMoGUbAnXWNJxi9FfnhdLG98SYPTGrc2t9zx5b7fxZvJdxxSSPEFKC1g==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-onto@0.1.4(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-onto@0.1.4(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-wbLRihJtU8PzfRTjzYIBSRIaMR5bam+qxmeRrjSJm7SOHaBUCvIF93MwhcdO6ShEIRoFYocx79dB7aE9bhrQBw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-particle@0.1.7(@solana/web3.js@1.70.1)(bs58@4.0.1):
+  /@solana/wallet-adapter-particle@0.1.7(@solana/web3.js@1.87.6)(bs58@4.0.1):
     resolution: {integrity: sha512-GK7h3yIY80tf94E3QOpuvhUOyNBkUKTEzU7DzPPuYWIqo1PPqvPunET1zso8H3KRJkwCuxyWFqVx4fB5f/+H4A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@particle-network/solana-wallet': 0.5.6(@solana/web3.js@1.70.1)(bs58@4.0.1)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@particle-network/solana-wallet': 0.5.6(@solana/web3.js@1.87.6)(bs58@4.0.1)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - bs58
     dev: false
 
-  /@solana/wallet-adapter-phantom@0.9.19(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-phantom@0.9.19(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-AMrS/iGDuSQmhRhEuZbJZ3gmooGqkY5Fck3aCVtZOTF7YgXnIJfwBRjgmHIVRCZVbyTDbMzlvDcHx85GN3MZsg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-safepal@0.5.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-safepal@0.5.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-g/GYTpY8A7Dn44qiuPQNN8e+ExwUtxEjrGsArwFTVI5YWkyoNMtRNu5anBf29YUZfya+fpQZBD7jUDhxBZ71dQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-saifu@0.1.12(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-saifu@0.1.12(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-EptM/g9C5tIr9vjfuvLb9Tj8aiObVLDhkr5Pr1vTEcI8GXW1Z6pv/a8Kcw0/gMBMt9ujZc1RkuiU2VC2iL/m6A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-salmon@0.1.11(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-salmon@0.1.11(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-43I/rBicXeAr0YClZD9OgkImFSQAj8dt6Z+OTOJFTbtDsYByD7FI28RAlR6cXeS9ZYhYw0gVNbhUO+vQQk9Xgg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
-      salmon-adapter-sdk: 1.1.1(@solana/web3.js@1.70.1)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
+      salmon-adapter-sdk: 1.1.1(@solana/web3.js@1.87.6)
     dev: false
 
-  /@solana/wallet-adapter-sky@0.1.12(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-sky@0.1.12(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-mRT7d+zXRiA+hjNJeyveN4yFqhxLH4aG7W4Cba9349YQlfn34wPVh1Nch7Xt733Ic+2ay8fz+ZdjlvE7UJEbMA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-slope@0.5.18(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-slope@0.5.18(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-d7XycT6KAuWnpAM51sPlR92DITk6dBOOUvgzkmd2VeCQzN4uebVRpLDL2xW4ma/cFz+brRxh55UzVcXX5zK/ZQ==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
     dev: false
 
-  /@solana/wallet-adapter-solflare@0.6.21(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-solflare@0.6.21(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-gaaAPzhmbYcI2m1H5RFDxIfrUD6lDv28wUds4VnBSrHEiwhP5Fz1EVpyl9gdiEujE+d31TYIU4wsc7ebudMmdg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
-      '@solflare-wallet/sdk': 1.2.0(@solana/web3.js@1.70.1)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
+      '@solflare-wallet/sdk': 1.2.0(@solana/web3.js@1.87.6)
     dev: false
 
-  /@solana/wallet-adapter-sollet@0.11.14(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-sollet@0.11.14(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-iE+QLS7eUhyMAiQB5MG/cYlhXMlprYKQtYSnxwgGmUOfIxXDX9HHMZiE3YJcsmtVODf2RvtM9ecd2BWiV1Fk1Q==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-solong@0.9.15(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-solong@0.9.15(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-rDvqLuLCbaLiozoSYv1B1+sb+M9/edav6iA5dg+qqTYNSw6alqXiUVy3cWO4oGPo25BOJue6YBXYU1Q0jA5Qhg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-spot@0.1.12(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-spot@0.1.12(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-reT95lHTt/bL6kVz2nUFmE2/OPL4+vcyqPm4+t7jAsUo4tjq9rIxnCOpxYPkQ8MXq83hflrSnPz5FJAKNFrPVA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-strike@0.1.10(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-strike@0.1.10(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-8IqEwEawELFYjhr1FrpiSEeHm9SYVtjG16dHcGgORhi59QqkebnVqkxfG3OCekPhBhayv9ToDPvyjJtv74aEXQ==}
     engines: {node: '>=16'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       '@strike-protocols/solana-wallet-adapter': 0.1.8
     transitivePeerDependencies:
       - bufferutil
@@ -3985,35 +3996,35 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-tokenary@0.1.9(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-tokenary@0.1.9(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-H6TPutI2Bhbg2UmVtWMdnhC7fFVeemI4PfqDRAaFBNRBeXOM0e6hvZWtidnvZ00tdQGYZMwjS0Tquz9d7vBwQw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-tokenpocket@0.4.16(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-tokenpocket@0.4.16(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-8b2FdlgQp+ZYJCiNwHklF0oixHpuYvTs4Cqkb3sOtO4HEJZDkRWaQkbw/6VwNB93bNrvHdYXNzzQt953i9upQg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-torus@0.11.25(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-torus@0.11.25(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-nOFKjatE1HcetkBV1mFETA+FfTS/G4FBASvJiTRExu/Hfd3hg4PqeYtgH4P3kbzlMvSkJ3ZiFfHPkppqp0snqg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
-      '@toruslabs/solana-embed': 0.3.2(@babel/runtime@7.20.13)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
+      '@toruslabs/solana-embed': 0.3.2(@babel/runtime@7.23.7)
       assert: 2.0.0
       crypto-browserify: 3.12.0
       process: 0.11.10
@@ -4027,35 +4038,35 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-trust@0.1.10(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-trust@0.1.10(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-mYEq1fUMCukxofdw1t+WQpChAfTBZNoljDoOzx/fAfTkcyc84w5c1VwS7x+5dMAdVvEZk3DNGVzGQwMJcLTU1A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-unsafe-burner@0.1.4(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-unsafe-burner@0.1.4(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-k+wySLMVFSNIlz2TyVcAQhPloRR0CMSPP2YtWHStgoNWXRNTLc1NLqed9me+GyzIDGgEC1yn6XeYy/oaYG3dfw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/wallet-adapter-walletconnect@0.1.10(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-walletconnect@0.1.10(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-DvJo0s0BZOaxxvpFDQ1vjAZuaAewVesCIY1xywegBK1XEK5Oh6szkDZNnEYjuRsQAzra1nJuT1soNaR+dBO0zQ==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@jnwng/walletconnect-solana': 0.1.4(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@jnwng/walletconnect-solana': 0.1.4(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - better-sqlite3
@@ -4063,58 +4074,58 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-wallets@0.19.10(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1)(bs58@4.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /@solana/wallet-adapter-wallets@0.19.10(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6)(bs58@4.0.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Q73Ormg5YN+IHFbP2M//UG1e4vdG/dhcUzUHW9AkLsWNWAT6jQ8vRRTtIJEwB2XyzW3O62mCgujYNrdCoDdhxA==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-alpha': 0.1.7(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-avana': 0.1.10(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-backpack': 0.1.11(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-bitkeep': 0.3.16(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-bitpie': 0.5.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-blocto': 0.5.19(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-brave': 0.1.14(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-censo': 0.1.1(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-clover': 0.4.16(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-coin98': 0.5.17(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-coinbase': 0.1.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-coinhub': 0.3.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-exodus': 0.1.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-fractal': 0.1.5(@solana/web3.js@1.70.1)(react-dom@18.2.0)(react@18.2.0)
-      '@solana/wallet-adapter-glow': 0.1.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-huobi': 0.1.12(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-hyperpay': 0.1.11(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-keystone': 0.1.9(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-krystal': 0.1.9(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-ledger': 0.9.22(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-magiceden': 0.1.10(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-mathwallet': 0.9.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-neko': 0.2.9(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-nightly': 0.1.12(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-nufi': 0.1.13(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-onto': 0.1.4(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-particle': 0.1.7(@solana/web3.js@1.70.1)(bs58@4.0.1)
-      '@solana/wallet-adapter-phantom': 0.9.19(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-safepal': 0.5.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-saifu': 0.1.12(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-salmon': 0.1.11(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-sky': 0.1.12(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-slope': 0.5.18(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-solflare': 0.6.21(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-sollet': 0.11.14(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-solong': 0.9.15(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-spot': 0.1.12(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-strike': 0.1.10(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-tokenary': 0.1.9(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-tokenpocket': 0.4.16(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-torus': 0.11.25(@babel/runtime@7.20.13)(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-trust': 0.1.10(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-unsafe-burner': 0.1.4(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-walletconnect': 0.1.10(@solana/web3.js@1.70.1)
-      '@solana/wallet-adapter-xdefi': 0.1.4(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-alpha': 0.1.7(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-avana': 0.1.10(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-backpack': 0.1.11(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-bitkeep': 0.3.16(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-bitpie': 0.5.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-blocto': 0.5.19(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-brave': 0.1.14(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-censo': 0.1.1(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-clover': 0.4.16(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-coin98': 0.5.17(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-coinbase': 0.1.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-coinhub': 0.3.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-exodus': 0.1.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-fractal': 0.1.5(@solana/web3.js@1.87.6)(react-dom@18.2.0)(react@18.2.0)
+      '@solana/wallet-adapter-glow': 0.1.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-huobi': 0.1.12(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-hyperpay': 0.1.11(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-keystone': 0.1.9(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-krystal': 0.1.9(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-ledger': 0.9.22(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-magiceden': 0.1.10(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-mathwallet': 0.9.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-neko': 0.2.9(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-nightly': 0.1.12(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-nufi': 0.1.13(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-onto': 0.1.4(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-particle': 0.1.7(@solana/web3.js@1.87.6)(bs58@4.0.1)
+      '@solana/wallet-adapter-phantom': 0.9.19(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-safepal': 0.5.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-saifu': 0.1.12(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-salmon': 0.1.11(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-sky': 0.1.12(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-slope': 0.5.18(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-solflare': 0.6.21(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-sollet': 0.11.14(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-solong': 0.9.15(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-spot': 0.1.12(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-strike': 0.1.10(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-tokenary': 0.1.9(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-tokenpocket': 0.4.16(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-torus': 0.11.25(@babel/runtime@7.23.7)(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-trust': 0.1.10(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-unsafe-burner': 0.1.4(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-walletconnect': 0.1.10(@solana/web3.js@1.87.6)
+      '@solana/wallet-adapter-xdefi': 0.1.4(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@react-native-async-storage/async-storage'
@@ -4130,47 +4141,89 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@solana/wallet-adapter-xdefi@0.1.4(@solana/web3.js@1.70.1):
+  /@solana/wallet-adapter-xdefi@0.1.4(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-5Z9gdn+SItrURBJYDS1vFp9PVqJ08RclNCH4BUJNM/KJIQ8T1uon7PADWnYvy43Q4uEqk7eUuKi25dlPp2NvBg==}
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.58.0
     dependencies:
-      '@solana/wallet-adapter-base': 0.9.20(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
     dev: false
 
-  /@solana/web3.js@1.70.1:
-    resolution: {integrity: sha512-AnaqCF1cJ3w7d0yhvLGAKAcRI+n5o+ursQihhoTe4cUh8/9d4gbT73SoHYElS7e67OtAgLmSfbcC5hcOAgdvnQ==}
-    engines: {node: '>=12.20.0'}
+  /@solana/wallet-standard-chains@1.1.0:
+    resolution: {integrity: sha512-IRJHf94UZM8AaRRmY18d34xCJiVPJej1XVwXiTjihHnmwD0cxdQbc/CKjrawyqFyQAKJx7raE5g9mnJsAdspTg==}
+    engines: {node: '>=16'}
     dependencies:
-      '@babel/runtime': 7.20.6
-      '@noble/ed25519': 1.7.1
+      '@wallet-standard/base': 1.0.1
+    dev: false
+
+  /@solana/wallet-standard-features@1.1.0:
+    resolution: {integrity: sha512-oVyygxfYkkF5INYL0GuD8GFmNO/wd45zNesIqGCFE6X66BYxmI6HmyzQJCcZTZ0BNsezlVg4t+3MCL5AhfFoGA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+    dev: false
+
+  /@solana/wallet-standard-util@1.1.0:
+    resolution: {integrity: sha512-vssoCIx43sY5EMrT1pVltsZZKPAQfKpPG3ib2fuqRqpTRGkeRFCPDf4lrVFAYYp238tFr3Xrr/3JLcGvPP7uYw==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@noble/curves': 1.2.0
+      '@solana/wallet-standard-chains': 1.1.0
+      '@solana/wallet-standard-features': 1.1.0
+    dev: false
+
+  /@solana/wallet-standard-wallet-adapter-base@1.1.1(@solana/web3.js@1.87.6)(bs58@4.0.1):
+    resolution: {integrity: sha512-+CPKbUZgiy0VpOWvy7sTpZYf04bB4eapslZNBg085zVLzNaFjrU9CYwudMLWbjlmZ4Wz0cE3DNtNwDtY0cj01A==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.58.0
+      bs58: ^4.0.1
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.87.6)
+      '@solana/wallet-standard-chains': 1.1.0
+      '@solana/wallet-standard-features': 1.1.0
+      '@solana/wallet-standard-util': 1.1.0
+      '@solana/web3.js': 1.87.6
+      '@wallet-standard/app': 1.0.1
+      '@wallet-standard/base': 1.0.1
+      '@wallet-standard/features': 1.0.3
+      '@wallet-standard/wallet': 1.0.1
+      bs58: 4.0.1
+    dev: false
+
+  /@solana/web3.js@1.87.6:
+    resolution: {integrity: sha512-LkqsEBgTZztFiccZZXnawWa8qNCATEqE97/d0vIwjTclmVlc8pBpD1DmjfVHtZ1HS5fZorFlVhXfpwnCNDZfyg==}
+    dependencies:
+      '@babel/runtime': 7.23.7
+      '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
-      '@noble/secp256k1': 1.7.0
       '@solana/buffer-layout': 4.0.0
+      agentkeepalive: 4.5.0
       bigint-buffer: 1.1.5
       bn.js: 5.2.1
       borsh: 0.7.0
       bs58: 4.0.1
-      buffer: 6.0.1
+      buffer: 6.0.3
       fast-stable-stringify: 1.0.0
-      jayson: 3.7.0
-      node-fetch: 2.6.7
-      rpc-websockets: 7.5.0
+      jayson: 4.1.0
+      node-fetch: 2.7.0
+      rpc-websockets: 7.5.1
       superstruct: 0.14.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
 
-  /@solflare-wallet/sdk@1.2.0(@solana/web3.js@1.70.1):
+  /@solflare-wallet/sdk@1.2.0(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-J3KZJdeYJ2R7jPHa0F53iCtkQEdcD1j7yeFQ4oa6Kk6gU1MOqSEWZxrr56sVDKWuPT/gunzEXGrgcwjd7nxwjg==}
     peerDependencies:
       '@solana/web3.js': ^1.61.0
     dependencies:
-      '@project-serum/sol-wallet-adapter': 0.2.0(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@project-serum/sol-wallet-adapter': 0.2.0(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       eventemitter3: 4.0.7
       uuid: 8.3.2
@@ -4310,7 +4363,7 @@ packages:
   /@strike-protocols/solana-wallet-adapter@0.1.8:
     resolution: {integrity: sha512-8gZAfjkoFgwf5fLFzrVuE2MtxAc7Pc0loBgi0zfcb3ijOy/FEpm5RJKLruKOhcThS6CHrfFxDU80AsZe+msObw==}
     dependencies:
-      '@solana/web3.js': 1.70.1
+      '@solana/web3.js': 1.87.6
       bs58: 4.0.1
       eventemitter3: 4.0.7
       uuid: 8.3.2
@@ -4436,15 +4489,15 @@ packages:
       rxjs: 7.8.0
     dev: false
 
-  /@toruslabs/base-controllers@2.5.0(@babel/runtime@7.20.13):
+  /@toruslabs/base-controllers@2.5.0(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-NL4l/Tu8Zk8wgW+2iEpmUwwg9tuZixTGKoC/hU6rki7cIVC7KUHjEcY8BQUxL5Zj+YM70EBAy+zHeFAMUt7GDg==}
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.23.7
       '@toruslabs/broadcast-channel': 6.1.1
-      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.20.13)
-      '@toruslabs/openlogin-jrpc': 2.9.0(@babel/runtime@7.20.13)
+      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.23.7)
+      '@toruslabs/openlogin-jrpc': 2.9.0(@babel/runtime@7.23.7)
       async-mutex: 0.4.0
       bignumber.js: 9.1.1
       bowser: 2.11.0
@@ -4506,6 +4559,21 @@ packages:
       loglevel: 1.8.1
     dev: false
 
+  /@toruslabs/http-helpers@3.2.0(@babel/runtime@7.23.7):
+    resolution: {integrity: sha512-fCfvBHfYzd7AyOYlBo7wihh5nj6+4Ik6V5+nI7H63oiKICjMlByTXSauTUa/qm2mjZJn/OmVYeV5guPIgxoW1w==}
+    engines: {node: '>=14.17.0', npm: '>=6.x'}
+    peerDependencies:
+      '@babel/runtime': ^7.x
+      '@sentry/types': ^7.x
+    peerDependenciesMeta:
+      '@sentry/types':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.7
+      lodash.merge: 4.6.2
+      loglevel: 1.8.1
+    dev: false
+
   /@toruslabs/metadata-helpers@3.0.0(@babel/runtime@7.20.13):
     resolution: {integrity: sha512-0eWCIbKpaBx3/z3BDyWebxUisCS37Uxb0zxOEWizSXjGH/T6TJCrBeZFPmANN3hq47GoNCsRiku9cgfij1UMTQ==}
     engines: {node: '>=14.17.0', npm: '>=6.x'}
@@ -4522,14 +4590,14 @@ packages:
       - '@sentry/types'
     dev: false
 
-  /@toruslabs/openlogin-jrpc@2.9.0(@babel/runtime@7.20.13):
+  /@toruslabs/openlogin-jrpc@2.9.0(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-68SMBSsFqayTi/uVJe1cffnz6QxYMtVLCF7h4HxlWxM27dd3030FspPrNJHFqt7o2u8/WSCB9pax9BrbTwYglw==}
     deprecated: Not supported. Pls upgrade
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
-      '@toruslabs/openlogin-utils': 2.1.0(@babel/runtime@7.20.13)
+      '@babel/runtime': 7.23.7
+      '@toruslabs/openlogin-utils': 2.1.0(@babel/runtime@7.23.7)
       end-of-stream: 1.4.4
       eth-rpc-errors: 4.0.3
       events: 3.3.0
@@ -4539,14 +4607,14 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /@toruslabs/openlogin-jrpc@3.2.0(@babel/runtime@7.20.13):
+  /@toruslabs/openlogin-jrpc@3.2.0(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-G+K0EHyVUaAEyeD4xGsnAZRpn/ner8lQ2HC2+pGKg6oGmzKI2wGMDcw2KMH6+HKlfBGVJ5/VR9AQfC/tZlLDmQ==}
     deprecated: Not supported. Pls upgrade
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
-      '@toruslabs/openlogin-utils': 3.0.0(@babel/runtime@7.20.13)
+      '@babel/runtime': 7.23.7
+      '@toruslabs/openlogin-utils': 3.0.0(@babel/runtime@7.23.7)
       end-of-stream: 1.4.4
       eth-rpc-errors: 4.0.3
       events: 3.3.0
@@ -4556,41 +4624,41 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /@toruslabs/openlogin-utils@2.1.0(@babel/runtime@7.20.13):
+  /@toruslabs/openlogin-utils@2.1.0(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-UVgjco4winOn4Gj0VRTvjSZgBA84h2OIkKuxrBFjS+yWhgxQBF4hXGp83uicSgx1MujtjyUOdhJrpV2joRHt9w==}
     deprecated: Not supported. Pls upgrade
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.23.7
       base64url: 3.0.1
       keccak: 3.0.3
       randombytes: 2.1.0
     dev: false
 
-  /@toruslabs/openlogin-utils@3.0.0(@babel/runtime@7.20.13):
+  /@toruslabs/openlogin-utils@3.0.0(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-T5t29/AIFqXc84x4OoAkZWjd0uoP2Lk6iaFndnIIMzCPu+BwwV0spX/jd/3YYNjZ8Po8D+faEnwAhiqemYeK2w==}
     deprecated: Not supported. Pls upgrade
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.23.7
       base64url: 3.0.1
       keccak: 3.0.3
       randombytes: 2.1.0
     dev: false
 
-  /@toruslabs/solana-embed@0.3.2(@babel/runtime@7.20.13):
+  /@toruslabs/solana-embed@0.3.2(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-yY0sTAi++lOM/kJ6tpR3/mRXqqpqrHNnm1PL/1Zkj1Tpnt+SmlPPp9ivveLXK+1vRLtha2UpjRk1KdsG+QJGyg==}
     engines: {node: '>=14.17.0', npm: '>=6.x'}
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
-      '@solana/web3.js': 1.70.1
-      '@toruslabs/base-controllers': 2.5.0(@babel/runtime@7.20.13)
-      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.20.13)
-      '@toruslabs/openlogin-jrpc': 2.9.0(@babel/runtime@7.20.13)
+      '@babel/runtime': 7.23.7
+      '@solana/web3.js': 1.87.6
+      '@toruslabs/base-controllers': 2.5.0(@babel/runtime@7.23.7)
+      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.23.7)
+      '@toruslabs/openlogin-jrpc': 2.9.0(@babel/runtime@7.23.7)
       eth-rpc-errors: 4.0.3
       fast-deep-equal: 3.1.3
       is-stream: 2.0.1
@@ -4605,17 +4673,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@toruslabs/torus-embed@1.41.2(@babel/runtime@7.20.13):
+  /@toruslabs/torus-embed@1.41.2(@babel/runtime@7.23.7):
     resolution: {integrity: sha512-EiKHz6+ab2hwXlyMF0B34MCTK7ooXa9FqY4DAezasunoKvevSKvwWmUOXlqfqUo/snxrEGFSMNtMe5LdLKIl4Q==}
     engines: {node: '>=14.17.0', npm: '>=6.x'}
     deprecated: Not supported. Pls upgrade
     peerDependencies:
       '@babel/runtime': 7.x
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.23.7
       '@metamask/obs-store': 7.0.0
-      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.20.13)
-      '@toruslabs/openlogin-jrpc': 3.2.0(@babel/runtime@7.20.13)
+      '@toruslabs/http-helpers': 3.2.0(@babel/runtime@7.23.7)
+      '@toruslabs/openlogin-jrpc': 3.2.0(@babel/runtime@7.23.7)
       create-hash: 1.2.0
       end-of-stream: 1.4.4
       eth-rpc-errors: 4.0.3
@@ -6142,6 +6210,12 @@ packages:
       - supports-color
     dev: false
 
+  /agentkeepalive@4.5.0:
+    resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      humanize-ms: 1.2.1
+
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -6759,12 +6833,6 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
     dev: false
-
-  /buffer@6.0.1:
-    resolution: {integrity: sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   /buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -8494,6 +8562,11 @@ packages:
     engines: {node: '>=12.20.0'}
     dev: true
 
+  /humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+    dependencies:
+      ms: 2.1.2
+
   /husky@8.0.3:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
@@ -8737,28 +8810,6 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: false
 
-  /jayson@3.7.0:
-    resolution: {integrity: sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      '@types/connect': 3.4.35
-      '@types/node': 12.20.55
-      '@types/ws': 7.4.7
-      JSONStream: 1.3.5
-      commander: 2.20.3
-      delay: 5.0.0
-      es6-promisify: 5.0.0
-      eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.9)
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      uuid: 8.3.2
-      ws: 7.5.9(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   /jayson@4.1.0:
     resolution: {integrity: sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==}
     engines: {node: '>=8'}
@@ -8779,7 +8830,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: false
 
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
@@ -9212,6 +9262,7 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: false
 
   /log-update@4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
@@ -9472,6 +9523,10 @@ packages:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
     dev: false
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: false
+
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -9531,6 +9586,18 @@ packages:
 
   /node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -10310,6 +10377,10 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: false
+
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   /regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
@@ -10472,28 +10543,16 @@ packages:
       bn.js: 5.2.1
     dev: false
 
-  /rpc-websockets@7.5.0:
-    resolution: {integrity: sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==}
-    dependencies:
-      '@babel/runtime': 7.20.13
-      eventemitter3: 4.0.7
-      uuid: 8.3.2
-      ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      bufferutil: 4.0.7
-      utf-8-validate: 5.0.10
-
   /rpc-websockets@7.5.1:
     resolution: {integrity: sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.23.7
       eventemitter3: 4.0.7
       uuid: 8.3.2
       ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
-    dev: false
 
   /rtcpeerconnection-shim@1.2.15:
     resolution: {integrity: sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==}
@@ -10557,13 +10616,13 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
 
-  /salmon-adapter-sdk@1.1.1(@solana/web3.js@1.70.1):
+  /salmon-adapter-sdk@1.1.1(@solana/web3.js@1.87.6):
     resolution: {integrity: sha512-28ysSzmDjx2AbotxSggqdclh9MCwlPJUldKkCph48oS5Xtwu0QOg8T9ZRHS2Mben4Y8sTq6VvxXznKssCYFBJA==}
     peerDependencies:
       '@solana/web3.js': ^1.44.3
     dependencies:
-      '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.70.1)
-      '@solana/web3.js': 1.70.1
+      '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.87.6)
+      '@solana/web3.js': 1.87.6
       eventemitter3: 4.0.7
     dev: false
 


### PR DESCRIPTION
Bump dependencies' versions and add a utility method to get the wallet standard compatible wallets ([repo](https://github.com/solana-labs/wallet-standard))