### PR TITLE
correctly handle semver (0.37.0 or higher)

### DIFF
--- a/packages/wallets/cosmos/src/cosmos.ts
+++ b/packages/wallets/cosmos/src/cosmos.ts
@@ -319,8 +319,8 @@ export class CosmosWallet extends Wallet<
     // from cosmjs: https://github.com/cosmos/cosmjs/blob/358260bff71c9d3e7ad6644fcf64dc00325cdfb9/packages/stargate/src/stargateclient.ts#L218
     let tmClient: TendermintClient;
     const tm37Client = await Tendermint37Client.connect(rpc);
-    const version = (await tm37Client.status()).nodeInfo.version;
-    if (version.startsWith("0.37.")) {
+    const [_major, minor, _patch] = (await tm37Client.status()).nodeInfo.version.split('.');
+    if (parseInt(minor, 10) >= 37) {
       tmClient = tm37Client;
     } else {
       tm37Client.disconnect();


### PR DESCRIPTION
I'm assuming that `version` is defined, and a string. the old code also assumes this.