### PR TITLE
Upgrade Aptos to latest `Aptos Wallet Adapter` version

### DIFF
--- a/packages/wallets/aptos/README.md
+++ b/packages/wallets/aptos/README.md
@@ -7,8 +7,8 @@ Implements the base abstractions for the Aptos blockchain.
 ```ts
 import { AptosWallet } from "@xlabs-libs/wallet-aggregator-aptos";
 
-const walletCore = AptosWallet.walletCoreFactory(aptosWalletConfig, true, []);
-walletCore.wallets.forEach((wallet) => {
-  new AptosWallet(wallet, walletCore);
-});
+const walletCore = AptosWallet.walletCoreFactory([], aptosWalletConfig, true);
+const aptosWallets = walletCore.wallets.map(
+  (wallet) => new AptosWallet(wallet, walletCore)
+);
 ```

--- a/packages/wallets/aptos/package.json
+++ b/packages/wallets/aptos/package.json
@@ -30,14 +30,9 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.33.1",
-    "@aptos-labs/wallet-adapter-core": "^4.23.0",
-    "@aptos-labs/wallet-standard": "^0.2.0",
-    "@bitget-wallet/aptos-wallet-adapter": "^0.1.2",
-    "@martianwallet/aptos-wallet-adapter": "^0.0.5",
-    "@pontem/wallet-adapter-plugin": "^0.2.1",
-    "@xlabs-libs/wallet-aggregator-core": "workspace:^",
-    "fewcha-plugin-wallet-adapter": "^0.1.3",
-    "petra-plugin-wallet-adapter": "^0.4.5"
+    "@aptos-labs/ts-sdk": "^1.35.0",
+    "@aptos-labs/wallet-adapter-core": "^5.0.0",
+    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@xlabs-libs/wallet-aggregator-core": "workspace:^"
   }
 }

--- a/packages/wallets/aptos/src/aptos.ts
+++ b/packages/wallets/aptos/src/aptos.ts
@@ -1,27 +1,23 @@
-import { AccountAuthenticator, Network } from "@aptos-labs/ts-sdk";
+import {
+  AccountAuthenticator,
+  InputSubmitTransactionData,
+  Network,
+  PendingTransactionResponse,
+} from "@aptos-labs/ts-sdk";
 
 import {
-  WalletName,
   NetworkInfo,
-  SignMessagePayload,
-  SignMessageResponse,
+  AptosSignMessageOutput,
   WalletCore,
-  AnyAptosWallet,
+  AdapterWallet,
   AnyRawTransaction,
   InputTransactionData,
-  Wallet as IAptosWallet,
   DappConfig,
+  AvailableWallets,
+  AptosSignMessageInput,
+  AccountInfo,
+  AptosSignAndSubmitTransactionOutput,
 } from "@aptos-labs/wallet-adapter-core";
-
-import { BitgetWallet } from "@bitget-wallet/aptos-wallet-adapter";
-import { MartianWallet } from "@martianwallet/aptos-wallet-adapter";
-import { PontemWallet } from "@pontem/wallet-adapter-plugin";
-import { FewchaWallet } from "fewcha-plugin-wallet-adapter";
-import { PetraWallet } from "petra-plugin-wallet-adapter";
-// FIXME: These wallets are not working
-// import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
-// import { MSafeWalletAdapter } from "@msafe/aptos-wallet-adapter";
-// import { TrustWallet } from "@trustwallet/aptos-wallet-adapter";
 
 import {
   BaseFeatures,
@@ -33,175 +29,94 @@ import {
   WalletState,
 } from "@xlabs-libs/wallet-aggregator-core";
 
-import type { Types as AptosLegacyTypes } from "aptos";
-
-export interface AptosSubmitResult {
-  hash: AptosLegacyTypes.HexEncodedBytes;
-}
-
-export type AptosMessage = string | SignMessagePayload | Uint8Array;
-export type SignedAptosMessage = string | SignMessageResponse;
-
-type AdapterIcon = {
-  icon: AnyAptosWallet["icon"];
-  name?: WalletName;
-};
-
-const NIGHTLY_WALLET: AdapterIcon = {
-  icon: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAxIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDIwMSAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0wLjM5MDYyNSAxMDBDMC4zOTA2MjUgNDQuNzcxNSA0NS4xNjIyIDAgMTAwLjM5MSAwQzE1NS42MTkgMCAyMDAuMzkxIDQ0Ljc3MTUgMjAwLjM5MSAxMDBDMjAwLjM5MSAxNTUuMjI4IDE1NS42MTkgMjAwIDEwMC4zOTEgMjAwQzQ1LjE2MjIgMjAwIDAuMzkwNjI1IDE1NS4yMjggMC4zOTA2MjUgMTAwWiIgZmlsbD0iIzYwNjdGOSIvPgo8cGF0aCBkPSJNMTQ2LjgzOCA0MEMxMzguMDU0IDUyLjI2MDcgMTI3LjA2MSA2MC43NjM0IDExNC4wNzIgNjYuNDQ3NEMxMDkuNTYzIDY1LjIwMjYgMTA0LjkzNiA2NC41Njg0IDEwMC4zNzkgNjQuNjE1NEM5NS44MjIzIDY0LjU2ODQgOTEuMTk1MSA2NS4yMjYxIDg2LjY4NTUgNjYuNDQ3NEM3My42OTY2IDYwLjczOTkgNjIuNzA0MiA1Mi4yODQyIDUzLjkxOTggNDBDNTEuMjY1NiA0Ni42NzA2IDQxLjA0ODMgNjkuNjg4OCA1My4zMDkxIDEwMS44NjdDNTMuMzA5MSAxMDEuODY3IDQ5LjM4NjYgMTE4LjY2MSA1Ni41OTc0IDEzMy4wODNDNTYuNTk3NCAxMzMuMDgzIDY3LjAyNiAxMjguMzYyIDc1LjMxNzMgMTM1LjAwOUM4My45ODQzIDE0Mi4wMzIgODEuMjEyOCAxNDguNzk2IDg3LjMxOTYgMTU0LjYyMUM5Mi41ODA5IDE2MCAxMDAuNDAyIDE2MCAxMDAuNDAyIDE2MEMxMDAuNDAyIDE2MCAxMDguMjI0IDE2MCAxMTMuNDg1IDE1NC42NDVDMTE5LjU5MiAxNDguODQzIDExNi44NDQgMTQyLjA3OSAxMjUuNDg4IDEzNS4wMzJDMTMzLjc1NSAxMjguMzg1IDE0NC4yMDcgMTMzLjEwNiAxNDQuMjA3IDEzMy4xMDZDMTUxLjM5NSAxMTguNjg1IDE0Ny40OTYgMTAxLjg5MSAxNDcuNDk2IDEwMS44OTFDMTU5LjcxIDY5LjY4ODggMTQ5LjUxNiA0Ni42NzA2IDE0Ni44MzggNDBaTTU5LjgzODcgOTcuNDI4MUM1My4xNjgxIDgzLjczNDYgNTEuMzM2MSA2NC45NDQyIDU1LjU0MDQgNTAuMDk5OEM2MS4xMDcxIDY0LjE5MjYgNjguNjcwMiA3MC41MTA5IDc3LjY2NjEgNzcuMTgxNEM3My44NjEgODUuMDk2OSA2Ni42OTcyIDkyLjU2NjEgNTkuODM4NyA5Ny40MjgxWk03OS4wMjg0IDEyMS41NUM3My43NjcxIDExOS4yMjUgNzIuNjYzMSAxMTQuNjQ1IDcyLjY2MzEgMTE0LjY0NUM3OS44MjcgMTEwLjEzNSA5MC4zNzMxIDExMy41ODggOTAuNzAxOSAxMjQuMjUxQzg1LjE1ODcgMTIwLjg5MyA4My4zMDMyIDEyMy40MDYgNzkuMDI4NCAxMjEuNTVaTTEwMC4zNzkgMTU5LjQxM0M5Ni42MjA5IDE1OS40MTMgOTMuNTY3NCAxNTYuNzEyIDkzLjU2NzQgMTUzLjRDOTMuNTY3NCAxNTAuMDg4IDk2LjYyMDkgMTQ3LjM4NyAxMDAuMzc5IDE0Ny4zODdDMTA0LjEzNyAxNDcuMzg3IDEwNy4xOSAxNTAuMDg4IDEwNy4xOSAxNTMuNEMxMDcuMTkgMTU2LjczNSAxMDQuMTM3IDE1OS40MTMgMTAwLjM3OSAxNTkuNDEzWk0xMjEuNzUzIDEyMS41NUMxMTcuNDc4IDEyMy40MjkgMTE1LjY0NiAxMjAuODkzIDExMC4wNzkgMTI0LjI1MUMxMTAuNDMyIDExMy41ODggMTIwLjkzMSAxMTAuMTM1IDEyOC4xMTggMTE0LjY0NUMxMjguMTE4IDExNC42MjEgMTI2Ljk5MSAxMTkuMjI1IDEyMS43NTMgMTIxLjU1Wk0xNDAuOTE5IDk3LjQyODFDMTM0LjA4NCA5Mi41NjYxIDEyNi44OTcgODUuMTIwNCAxMjMuMDY4IDc3LjE4MTRDMTMyLjA2NCA3MC41MTA5IDEzOS42NTEgNjQuMTY5MSAxNDUuMTk0IDUwLjA5OThDMTQ5LjQ0NSA2NC45NDQyIDE0Ny42MTMgODMuNzU4MSAxNDAuOTE5IDk3LjQyODFaIiBmaWxsPSIjRjdGN0Y3Ii8+Cjwvc3ZnPgo=",
-};
-
-const SNAP_WALLET: AdapterIcon = {
-  icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAQIElEQVRoge2Za5BlV1XHf2vvcx/d0+m+3Zln5tUdkspDKYaYRKMp6alUIIDUdAop+KBkYnyBlomlH+AT4yeUssxgiaQEzaCIZUnJxBIQ8mE6MBQIASYhyUzIo++k59EzPTN9u6ef5+y9lh/2vnc6RtEqUD7oqeo65957ep+19vqv//+/94H/P368h3QvHn7L45973dYbOlfVmx/d+4nNx36cQf1nx5FfnR2fXZqbmOmc3v07X9x7L+QEHr7nyGiMK1NikR0ju9k2dE27JhzAVU/c8ci29o816P1TrbobeDAK42cXzoyfmT9NNKi8jH3wX97aLgDKsDIhRMSUk+efZ2n50ujY1dce6i8aPPnAucM15PAb/nLzp/63gv7u/qkWRXNPMP+hiI2XVnHizHN0VjrgCxCPC34COFgAiLDPVDENgHFu/hQLi+fZs+t2Boq+CUMnnr7/7IGaMFlo+NT1h3ZO/k8Efnz/9LiKTESp3RfVWiLG4soCT5/5DmWMiPeYCuIEcX4fcFA+fM8XRyWEKYsVZgFihWlAVFGruG7j9dy4+Sa8GR6jAAqs7bEDav6JsUM/HMSm9k+1HPUHgzARkD1RhIgQBF668CLHZ54F5/G+Ac5j4vFFHaRgNYThQuPqOCqYBcQUtQSlaBVixomzz7C8Os/NW36CwfoGwDBjFDhUWODs/ulJ7+VQbaedLHJQRf4DIKQPgSt/ANXpMBqr4r4KxiOGId2xqbTia1NHmVu+hDmPmKOKazgaiBOiRnBCvajtL0z9faolmGGxQtQwU6IqaEQwpi6+yMz8NOPX7mXjhpH0IEAQDBs3jeMidcwML4AZKiCaglcj3S+CLxwxGqZpjFcdBucXZ/h6+2usxDWcq4Gmn8TXiBoRBBGXnu7cPv+m0XcdhNhM+FeiBlQDmGIWCbEElNVqhRfOn0BNuWbwGsRA8ryJgetzSCOzsnMpwEIwwJxgzmEimEJcNuJlIwKKoICK8My5Z/jqS5OUWnVHBudAHIagYkj3c/q55e8Yffs9Tt2omWIaUYuYRWJu6KgVqum3SivOzL/C7OI5tg5upVE0uo9BIrghDy5PpRPMSTqLYALqBBUhdJRYpipFYKFc5IsnPs8zM9/rBWeSEkPSNKkZiIAIwRQRjxrfKLzWnwpWjZMDRxVTzcEHzMBQ1BTN9XzxwgucuzzDm6+/m9HWTkQcYU1xBs4LZoKYIVknTRKETEADhMuKWpr96flpvvT9L7Owtoj3nmgRFArxKQaLoA6XsEnUiDkwDThnT/if27Wvqcp7VAOmKQnNFdAYMJSgiaHUlHSfslwu8fTZY6gYu0dGQUG8IP0uRepy0I4MkQSlsGiERUUFJqe+wueP/zNlrFAMSPAAh5KqYMiVM2DO96Al+IP+umt3r26IWx+ybgUwQiwxMzQnZKZEi2iMRIsEDb3v2pfavHzxJXYNj9Es+vAjPlXNu3TOEMIJ5oW1c4FLl+f522N/x9Nnn8IEoiUWkox1pBs0KVgRxPlc/y7EHAT/QQF46I6PzblYtAQlhNVUZ1WilogZqlWqhkU0V0atIsaQKmWRgUYf77hpglvvvAVXpAqIga2jGi2NZ588zqe/89eUoaRwDUQ8znucFDhXQ5zDuxriPOIKnCuQ/IfzOFdHvAeptf/kGw+MuTR0bTJapIwlaoZiBIuoGUEjwSLBNF1rJKIEVYJFDKGywLnlWT755Cc4cepFYiGoF6KksxZC9MKJ0y/ysa//GYvlEpUpa1oSLY0Vc0VjvlZIZyPFghI0EC0QVVGLT6V6AJWGJ6Jpgo0paqlZ1IxggRBTE6dEUhKVRSLCsq6xZpFGbYB33/5eRkeuR7OaqhfUpetoMLb5et77s7+OrzXTOEBlKeDSApVFAgmiZayIFim1zBOpmEHIiZa2dgxA3n/bx/aY6RFUW2Yx+aEMEY1VotasDUEDphWVGSFbj2CBvr4BfvPO32Bnazv+KqG2qUgtF4EiM5FBNRuJy8bswkX+9MhBlpcvg/PUpE7dFwlOzlPzdZwrQBziCryvJwPnCsQXGVq1TvTyRv+tM1+YuWXzm59X9D2JhbKYmRJjQDOE1IxAZE27MxapLHB1awvv2/vbbBneijmQPocfyCziUgNqptC4AqrQrPfzkzv38J1T32W5WkVxRBzifGKaLJHO+aTiXRIgNW8SMXnrI9/8rWMeYM+2ez5upqNqkRgrDKXK52BK1EhpFZWmz8GMVV1jz9hPcd/4AwxuGErs4RPTuA3pgbgromQiVEuJH6xwNBt93Pq6Ozg9f46ZhXNJpHBEESQnHYXETD0dyRRrELCxYzNfOuQB3rD1rqdM9R41a1kOeC1jMGjCZjSjtEipCTZ37Xkz997xLoparTfTeIEC/FUOM7kSPKkXwooRLSuyF3y9zhuvvRWc49mzzyPikl6IELPfUnG9RLpaYU7aUNx/bOZLMwXA6mrs1OrSSjivCJo8YzRNjWXa4/6+5gA///px9r5+HNWkO84JmCU+zw2c/VbPpBkQLVVILQlcVyfuuuUeKjO++fy3WC6XMFXEJZNSacBn1fbOE63EaY26T4MXAM1ms7MWltrB4p5KI3TpUwOFb7JrZAfXtHZz45abaPUPMnRNA0tKD9b1LMmdSpGMmfRW21cSiS5VSWN2oi4nI3D3T7+N23fdxYXOHKc6r/DyheeZWThFCBX4JChRk9t1SmfZL7fXDQ0TNx4YNeKRoHF0S2sHW4d2sG1oFzuGd+MAZ4aYMbTL44vsdbr+ygyRZK5Ro7nJZwEVzLLTF1g9p71m1GgZ29noabLdl88qqhBzdU5fOsns8nnaF77Phc4ZvCvaDrf38IkDr04A4M9/5eRDG+r9Dzd9AzHDuxS4syQYzUFoXOVwHkRTYC6PINoTfpqbXBpYwCJIAaawel5To2eoWYZW13KrGuUiLHcUzR5IoWe7V7VkeW3pd9//V7sPdmMu1ifQGrp6X5rNvBjJU2cYhuIGBOoJAi7zezTDCZiXZOgE1ATpQsxfCVK9pM/a9UegaphlBnMC/RFZE6gyKVjqMVOo06De39wH9BLoVeDRD8yNNqw+5SSvqjTPPhkiZsxf6hBWKwTDIxR1hwN8kauSH7bzjSMpAa7AKFbK2WcXCEExhVDFlJgJIRoxGhGj3ldncGQQxGcYQdTcLwgRKNfK4fsPDndeVYF6szYumjrfcuD0qpAa9Opdw1x4ZZ6wWoIIsVQEwVUxuzajKBzRBO97XyEuCdtCZw3VtBjtQUfyYgWh6KszvLOFxRSsWApcNN3bJQpfr00AhyB7IQB8bZ/UBdcQpCZIXZDudUOgkZaFG8dauGaNyoyIIwBL1RpTc20iDteoEzLtWbbQKomZir4GEeHluSnmVueJ4ggYKg7qno2jrSR+dcGK/NwauEaCLjmuou7vexWEHn3YWs1ybc7lda53gCZsi4ETQzLnSwSNyvmX51haXuTb7aM8efIoGLx//INs2jLMthsGaAykubHsp8tl4+zxRaZPn+bjX/kjBvuG2Tl8LXdefzdDV42wZWwY3yiSZkheBJlAvjYnxEh3XdFZWayP3X9AOg6gQTnuGilj11xXgZrg6gKF632mIVBzDOxsYDsvclFOsRLWWAmr/Gv7q/i+Wm/WY5dd8vrYNQu+8uLjyYKzRtywzOLGabbfeDWuVkAB0uzOtLuCgkaKx/cJUgfztOpD1USvB6TGhIj0+Jy8nk2eKVUh76Pk3QjYMDDAbTffxu233sbyyhLHX3ie7z13HN/n0zrASXcvBcOIAlUtcPMbbmDfu97C7u276O/fgAEXpxU8+GYStkTBQgZCFkXJzxd8+vlNwCEB+IdPVHOYtVy3KTI1otmTdduuO5ga1bIxsj1xZZfKBFiYUYomNDOEuoq8uqiUyzC0zfX2g7rKceGVSOOqtGWYt4ESbHLQXUdq3e9FUKOzVCvGis9+MkyYt5ZHMtsYWYbo2hmx7qMEkVydqrvnJL0EAKglrteuwOWziiBNiOvutnX/4+pJGyRXujv7JlfGNwOXt1aA1gBhTzE7a3ucSzOdgs2NCylYg4WF81TVaq6C4cSh0Xj9yG58bZ2YWGKMLn+T1RZAXdpY7s5wN4EYoT39CuK7ymyIOIpak6GhzYliXRpTFUySBVEBVzBRnDvHpIMPWcwM1IVM1gInxvJSnemzL7yqMo1Gna3bdzE0IjT7U98ggu+DajXvRpgh+awiuGz0usfaijE3a7Tbs6yupvVHd1dibMctLC9Y0gOXztFyZSWJmyuKIw6KY2UlnWCpvGWESqGMUCpU6qj3tRhq7UC9x7wniqPW109ZCbPnoDNnyeMDFIK6dVjNZzz4Rt5GJP3P+bNQmVDr25C0wNdR8bSGd0PRpFLJMQmVQhWhCkIZIJgwZzzhDhyUzhp2rIxGGYwqGmU0ggmVGmVUKoXBwe24og/FI0UNV28QTAgKnUswOwNVSDPsG0nAzOWNLQeulnYpgsH5GWPuYtqprkqoN/sxn7bOa40BBga2UUajMiijUZqxFpRKlcqMyowy6uTBg9IpAKpq7THn/HjX44gm7+O6VjmXvDW0m4vzbaIZzQ0DrFWGc8n7V/OwtGyIP8Y/Pv5pllcu9xovocb45Xf+Aba6lVBJl2FRwNeb4OtEMzZd/TrKGBDvCSFmHncE0/R+wCJBDefcY5B1YNVVh13Uhx2kBDBUlSIbQjI3+3qDZnOElbKDbzQIJJ/inHBN4zi3DR7mI//0Zb799Py6wKHb5scefy/ve9u7+dbCBPPVxrTodeCbfagraDYGiUDUiBMjWNpKSVA0NCY7EDRiUj/cS+CRR4bbv/bAXNvBaOBKM5fa3SNIlfDmqDUHWQ4ruFqTYMLO5gl+ZuhzbG+cAGC6E3uzmxmxZyemL61yQ/9Rbug/yvGlO/nG/L3Mh02YFEjRoN4YYjWGRK9R8jLUQFy2Fpp2JJy0/+KRvnYvAYAqVo8hPOhEcJZw5zMHJ/pUJCZ1rDeH2Nn/Ans3f4GdzROsPxZWYs/P0E0/k/t0J/Tuu2nDUW7acJRTazcyKe9g9tIWStKMqxniPNES6appFrG0wNAq9t7RrXsTFA+L8WA0wGLiek34cSKYVp2aq08qTIqvPfZ295E9zdI/SlNa6xMYKTxvu26If38IcLkMr/l+eO3Zzi/Unrv3a3y4Ha05rjHsM+fGLcZWerGhRM364Fza+pfwqfXjArB//1Srin4KJy0zw6KCMOmdPFGomzz06de+mZz6wMRozdeODG30owOtZB3az5WvCXL9MXpzHY3GwiVl4ZK2lWrv2B8efs2Lwv37p8c16HiFvck5Nw7djWLrfOZvdg+/JgGAd//SS59DOWnOTZYFk4cPjXV+YDT5eOn33nmw3nAPDrQcndn4A+9tbfIsXFSC6kddFQ+MHTz8Xz5jYmKqVe9j3HmbMNXO33/muof+wwR+mGPq939xHJFHwUZ/8J3Sxuz+sT/+7I/kXfOPLAFIkNLoH3Lw2iYAMDlJCAf/O7P+f+b4N+Rutnf3n55sAAAAAElFTkSuQmCC",
-};
-
-const BITGET_WALLET: AdapterIcon = {
-  icon: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgdmlld0JveD0iMCAwIDI1NiAyNTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMF8yMDM1XzExMDYpIj4KPHJlY3Qgd2lkdGg9IjI1NiIgaGVpZ2h0PSIyNTYiIGZpbGw9IiM1NEZGRjUiLz4KPGcgZmlsdGVyPSJ1cmwoI2ZpbHRlcjBfZl8yMDM1XzExMDYpIj4KPHBhdGggZD0iTTEzLjQ4MDYgMTk4LjYwNUMtMjkuMzI3NiAzMTkuMDQzIDE5OS42NjEgMjg1LjAyNyAzMTkuNTA3IDI1Mi45NjRDNDQyLjE2NSAyMTIuMjU5IDM1Ny4zODYgMzIuODI2OSAyNjkuNDE1IDI4Ljg1NThDMTgxLjQ0MyAyNC44ODQ3IDI4MC4zMjIgMTExLjgyNCAyMDUuNTk1IDEzNi42NTZDMTMwLjg2OCAxNjEuNDg3IDY2Ljk5MDcgNDguMDU4MyAxMy40ODA2IDE5OC42MDVaIiBmaWxsPSJ3aGl0ZSIvPgo8L2c+CjxnIGZpbHRlcj0idXJsKCNmaWx0ZXIxX2ZfMjAzNV8xMTA2KSI+CjxwYXRoIGQ9Ik04NS41MTE4IC00NS44MjI1QzYzLjA1NjIgLTEwNy4xNzYgLTE2LjkxODkgLTIzLjk5NTMgLTU0LjA5OTUgMjUuMjY0M0MtODkuNTY1MiA3OC44NDc5IDMuMDA5MzcgMTI1LjE1MiAzOS4zMjA4IDEwMC4wMzdDNzUuNjMyMyA3NC45MjI3IDcuNzc0NDggNzAuMDM2MyAyOS4zNzA4IDM3LjM3ODVDNTAuOTY3MSA0LjcyMDc2IDExMy41ODEgMzAuODY5NSA4NS41MTE4IC00NS44MjI1WiIgZmlsbD0iIzAwRkZGMCIgZmlsbC1vcGFjaXR5PSIwLjY3Ii8+CjwvZz4KPGcgZmlsdGVyPSJ1cmwoI2ZpbHRlcjJfZl8yMDM1XzExMDYpIj4KPHBhdGggZD0iTTk2LjQ3OTYgMjI1LjQyNEM2NS44NTAyIDEyMi4zNjMgLTY2LjA4MTggMTc2LjYzNyAtMTI4LjIxOSAyMTYuNjU3Qy0xODcuOTkgMjY0LjA0MiAtNDYuMDcxMSA0MDAuMzQ4IDEyLjg3MjUgMzkzLjM3NkM3MS44MTYxIDM4Ni40MDMgLTM0LjQxMTggMzI3LjA2NSAxLjk4NzAyIDI5OC4xN0MzOC4zODU4IDI2OS4yNzYgMTM0Ljc2NiAzNTQuMjQ5IDk2LjQ3OTYgMjI1LjQyNFoiIGZpbGw9IiM5RDgxRkYiLz4KPC9nPgo8ZyBmaWx0ZXI9InVybCgjZmlsdGVyM19mXzIwMzVfMTEwNikiPgo8cGF0aCBkPSJNMjgyLjEyIC0xMDcuMzUzQzIxNi4wNDcgLTE4Ni4wMzEgMTIxLjQ2MyAtMTIwLjk3IDgyLjQyOTYgLTc4LjYwNDdDNDguMjczOSAtMzAuNjQ0NiAyMjQuMjc1IDU3LjIzMTIgMjczLjEyMSA0Mi4xNzE0QzMyMS45NjggMjcuMTExNSAyMDYuNTEyIC00LjA1MDM4IDIyNy4yOTcgLTMzLjI4NzlDMjQ4LjA4MiAtNjIuNTI1NSAzNjQuNzEyIC05LjAwNTY2IDI4Mi4xMiAtMTA3LjM1M1oiIGZpbGw9IiM0RDk0RkYiLz4KPC9nPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTkzLjE4OSAxNTIuODM2SDEzNi42NzRMODcuMjA4NiAxMDMuMDUxTDEzNy4zMSA1My4yNjYzTDE1MC45NTUgNDBIMTA1LjgxOUw0OC4zMzU5IDk3Ljc3NzNDNDUuNDM0OSAxMDAuNjg5IDQ1LjQ0OTggMTA1LjQwMiA0OC4zNjU2IDEwOC4yOTlMOTMuMTg5IDE1Mi44MzZaTTExOS4zMyAxMDMuMTY4SDExOC45OTVMMTE5LjMyNiAxMDMuMTY0TDExOS4zMyAxMDMuMTY4Wk0xMTkuMzMgMTAzLjE2OEwxNjguNzkxIDE1Mi45NDlMMTE4LjY5IDIwMi43MzRMMTA1LjA0NSAyMTZIMTUwLjE4TDIwNy42NjQgMTU4LjIyNkMyMTAuNTY1IDE1NS4zMTQgMjEwLjU1IDE1MC42MDIgMjA3LjYzNCAxNDcuNzA1TDE2Mi44MTEgMTAzLjE2OEgxMTkuMzNaIiBmaWxsPSJibGFjayIvPgo8L2c+CjxkZWZzPgo8ZmlsdGVyIGlkPSJmaWx0ZXIwX2ZfMjAzNV8xMTA2IiB4PSItOTAuMjQxMSIgeT0iLTY5LjczNjkiIHdpZHRoPSI1NjkuNTU4IiBoZWlnaHQ9IjQ1MS40MzEiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0ic2hhcGUiLz4KPGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iNDkuMjMwOCIgcmVzdWx0PSJlZmZlY3QxX2ZvcmVncm91bmRCbHVyXzIwMzVfMTEwNiIvPgo8L2ZpbHRlcj4KPGZpbHRlciBpZD0iZmlsdGVyMV9mXzIwMzVfMTEwNiIgeD0iLTE2MC41MTEiIHk9Ii0xNjUuOTg3IiB3aWR0aD0iMzUxLjU5NiIgaGVpZ2h0PSIzNzEuNTA3IiBmaWx0ZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIGNvbG9yLWludGVycG9sYXRpb24tZmlsdGVycz0ic1JHQiI+CjxmZUZsb29kIGZsb29kLW9wYWNpdHk9IjAiIHJlc3VsdD0iQmFja2dyb3VuZEltYWdlRml4Ii8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW49IlNvdXJjZUdyYXBoaWMiIGluMj0iQmFja2dyb3VuZEltYWdlRml4IiByZXN1bHQ9InNoYXBlIi8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjQ5LjIzMDgiIHJlc3VsdD0iZWZmZWN0MV9mb3JlZ3JvdW5kQmx1cl8yMDM1XzExMDYiLz4KPC9maWx0ZXI+CjxmaWx0ZXIgaWQ9ImZpbHRlcjJfZl8yMDM1XzExMDYiIHg9Ii0yNDEuMDc4IiB5PSI2Ny42NDIiIHdpZHRoPSI0NDQuODUxIiBoZWlnaHQ9IjQyNC40NTIiIGZpbHRlclVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY29sb3ItaW50ZXJwb2xhdGlvbi1maWx0ZXJzPSJzUkdCIj4KPGZlRmxvb2QgZmxvb2Qtb3BhY2l0eT0iMCIgcmVzdWx0PSJCYWNrZ3JvdW5kSW1hZ2VGaXgiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJCYWNrZ3JvdW5kSW1hZ2VGaXgiIHJlc3VsdD0ic2hhcGUiLz4KPGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iNDkuMjMwOCIgcmVzdWx0PSJlZmZlY3QxX2ZvcmVncm91bmRCbHVyXzIwMzVfMTEwNiIvPgo8L2ZpbHRlcj4KPGZpbHRlciBpZD0iZmlsdGVyM19mXzIwMzVfMTEwNiIgeD0iLTIwLjM5NjgiIHk9Ii0yNDIuNzU4IiB3aWR0aD0iNDMwLjE5MSIgaGVpZ2h0PSIzODUuMTA1IiBmaWx0ZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIGNvbG9yLWludGVycG9sYXRpb24tZmlsdGVycz0ic1JHQiI+CjxmZUZsb29kIGZsb29kLW9wYWNpdHk9IjAiIHJlc3VsdD0iQmFja2dyb3VuZEltYWdlRml4Ii8+CjxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW49IlNvdXJjZUdyYXBoaWMiIGluMj0iQmFja2dyb3VuZEltYWdlRml4IiByZXN1bHQ9InNoYXBlIi8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjQ5LjIzMDgiIHJlc3VsdD0iZWZmZWN0MV9mb3JlZ3JvdW5kQmx1cl8yMDM1XzExMDYiLz4KPC9maWx0ZXI+CjxjbGlwUGF0aCBpZD0iY2xpcDBfMjAzNV8xMTA2Ij4KPHJlY3Qgd2lkdGg9IjI1NiIgaGVpZ2h0PSIyNTYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==",
-  name: "Bitget Wallet" as WalletName<"Bitget Wallet">,
-};
-
-const OVERRIDES: Record<string, Partial<AnyAptosWallet>> = {
-  nightly: NIGHTLY_WALLET,
-  snap: SNAP_WALLET,
-  bitkeep: BITGET_WALLET,
-  bitget: BITGET_WALLET,
-};
-
-/**
- * Attempt to get an override for the given adapter.
- *
- * @param adapter Aptos adapter to get the override for or default to itself
- * @returns the current adapter or the override if it exists
- */
-const getOverride = (adapter: AnyAptosWallet): Partial<AnyAptosWallet> =>
-  OVERRIDES[adapter.name.toLocaleLowerCase()] || adapter;
-
-/**
- * Looks for a property in the overrides and returns it if it exists, otherwise returns the property from the adapter.
- *
- * @param propertyName property name to look for
- * @param overrides overrides to inspect for the property
- * @param adapter adapter to default to if the property is not found in the overrides
- * @returns the property value from the overrides if it exists, otherwise the property value from the adapter
- */
-const getPropertyByName = <T>(
-  propertyName: keyof AnyAptosWallet,
-  overrides: Partial<AnyAptosWallet>,
-  adapter: AnyAptosWallet
-): T => (overrides[propertyName] || adapter[propertyName]) as T;
-
-/**
- * Looks for a property value if overrides exist return it otherwise defaults to adapter value.
- * @param propertyName property name to look for
- * @param adapter adapter to default to if the property is not found in the overrides
- * @returns the property value
- */
-const getWalletOverride = <T>(
-  propertyName: keyof AnyAptosWallet,
-  adapter: AnyAptosWallet
-): T => getPropertyByName<T>(propertyName, getOverride(adapter), adapter);
-
 type SendTransactionInput = {
   transaction: AnyRawTransaction;
   senderAuthenticator: AccountAuthenticator;
 };
 
+type SignTransactionInput = {
+  transactionOrPayload: AnyRawTransaction | InputTransactionData;
+  asFeePayer?: boolean;
+};
+type SignTransactionOutput = Promise<{
+  authenticator: AccountAuthenticator;
+  rawTransaction: Uint8Array;
+}>;
+
 export class AptosWallet extends Wallet<
   typeof CHAIN_ID_APTOS,
   void,
-  AnyRawTransaction,
-  AccountAuthenticator,
-  SendTransactionInput,
-  AptosSubmitResult,
+  SignTransactionInput,
+  SignTransactionOutput,
+  InputSubmitTransactionData,
+  AptosSignAndSubmitTransactionOutput,
   InputTransactionData,
-  AptosSubmitResult,
-  AptosMessage,
-  SignedAptosMessage,
+  AptosSignAndSubmitTransactionOutput,
+  AptosSignMessageInput,
+  AptosSignMessageOutput,
   NetworkInfo
 > {
   private address: string | undefined;
+  private account: AccountInfo | null = null;
   private network: NetworkInfo | undefined;
   /**
    * @param selectedAptosWallet The Aptos wallet adapter which will serve as the underlying connection to the wallet
    * @param walletCore WalletCore class obtained via walletCoreFactory static function
    */
   constructor(
-    private readonly selectedAptosWallet: AnyAptosWallet,
+    private readonly selectedAptosWallet: AdapterWallet,
     private readonly walletCore: WalletCore
   ) {
     super();
   }
 
   /**
-   * @param config WalletCore configuration
-   * @param withNonStandard Add nonstandard wallets to the wallet core, these includes the following wallets:
-   * - BitgetWallet
-   * - MartianWallet
-   * - MSafeWalletAdapter
-   * - OKXWallet
-   * - PontemWallet
-   * - TrustWallet
-   * - FewchaWallet
-   * - PetraWallet
-   * @param newWalletsToAdd Add new wallets to the wallet core
+   * @param optInWallets the adapter detects and adds AIP-62 standard wallets by default,
+   * sometimes you might want to opt-in with specific wallets.
+   * This props lets you define the AIP-62 standard wallets you want to support in your dapp
+   * @param config Config used to initialize the dapp with
+   * @param disableTelemetry A boolean flag to disable the adapter telemetry tool, false by default
    * @returns {WalletCore} WalletCore instance
    */
   static walletCoreFactory(
-    config: DappConfig = { network: "mainnet" as Network },
-    withNonStandard = true,
-    newWalletsToAdd: IAptosWallet[] = []
+    optInWallets?: ReadonlyArray<AvailableWallets>,
+    config?: DappConfig,
+    disableTelemetry?: boolean
   ): WalletCore {
-    const nonStandardWallets: IAptosWallet[] = [
-      // We are forcing PetraWallet to avoid the NotDetected issue
-      new PetraWallet(),
-      // ---------------------------------------------------------
-      new BitgetWallet(),
-      new MartianWallet(),
-      new PontemWallet(),
-      // FIXME: These wallets are not working!!
-      new FewchaWallet() as IAptosWallet,
-      // new OKXWallet(),
-      // new MSafeWalletAdapter(),
-      // new TrustWallet() as IAptosWallet,
-    ];
-
-    return new WalletCore(
-      withNonStandard
-        ? [...nonStandardWallets, ...newWalletsToAdd]
-        : newWalletsToAdd,
-      // FIXME: T Wallet is not working and is removed from available wallets.
-      [
-        "Nightly",
-        "Continue with Google",
-        "Continue with Apple" as any,
-        "Mizu Wallet",
-        "Pontem Wallet",
-      ],
-      config,
-      true
-    );
+    return new WalletCore(optInWallets, config, disableTelemetry);
   }
 
   getName(): string {
-    return getWalletOverride("name", this.selectedAptosWallet);
+    return this.selectedAptosWallet.name;
   }
 
   getUrl(): string {
     return this.selectedAptosWallet.url;
   }
 
+  getAccount(): AccountInfo | null {
+    return this.account;
+  }
+
   async connect(): Promise<string[]> {
     await this.walletCore.connect(this.selectedAptosWallet.name);
 
+    // set account
+    this.account = this.walletCore.account;
+
     // Set address
-    this.address = this.walletCore.account?.address;
-    this.walletCore.on("accountChange", async (accountInfo) => {
-      this.address = accountInfo?.address;
-    });
+    this.address = this.account?.address.toString();
+    this.walletCore.on(
+      "accountChange",
+      async (accountInfo: AccountInfo | null) => {
+        this.account = accountInfo;
+        this.address = accountInfo?.address.toString();
+      }
+    );
 
     // Set network
     this.network = this.walletCore.network || undefined;
-    this.walletCore.on("networkChange", async (network) => {
+    this.walletCore.on("networkChange", async (network: NetworkInfo | null) => {
       this.network = network || undefined;
     });
 
@@ -243,13 +158,18 @@ export class AptosWallet extends Wallet<
     throw new NotSupported();
   }
 
-  async signTransaction(tx: AnyRawTransaction): Promise<AccountAuthenticator> {
-    return this.walletCore.signTransaction(tx);
+  async signTransaction(
+    tx: SignTransactionInput
+  ): Promise<SignTransactionOutput> {
+    return this.walletCore.signTransaction({
+      transactionOrPayload: tx.transactionOrPayload,
+      asFeePayer: tx.asFeePayer,
+    });
   }
 
   async sendTransaction(
-    txInput: SendTransactionInput
-  ): Promise<SendTransactionResult<AptosSubmitResult>> {
+    txInput: InputSubmitTransactionData
+  ): Promise<SendTransactionResult<PendingTransactionResponse>> {
     const result = await this.walletCore.submitTransaction({
       transaction: txInput.transaction,
       senderAuthenticator: txInput.senderAuthenticator,
@@ -257,13 +177,13 @@ export class AptosWallet extends Wallet<
 
     return {
       id: result.hash,
-      data: { hash: result.hash },
+      data: result,
     };
   }
 
   async signAndSendTransaction(
     tx: InputTransactionData
-  ): Promise<SendTransactionResult<AptosSubmitResult>> {
+  ): Promise<SendTransactionResult<AptosSignAndSubmitTransactionOutput>> {
     const result = await this.walletCore.signAndSubmitTransaction(tx);
     return {
       id: result.hash,
@@ -271,12 +191,14 @@ export class AptosWallet extends Wallet<
     };
   }
 
-  async signMessage(msg: SignMessagePayload): Promise<SignedAptosMessage> {
+  async signMessage(
+    msg: AptosSignMessageInput
+  ): Promise<AptosSignMessageOutput> {
     return this.walletCore.signMessage(msg);
   }
 
   getIcon(): string {
-    return getWalletOverride("icon", this.selectedAptosWallet);
+    return this.selectedAptosWallet.icon;
   }
 
   getWalletState(): WalletState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,32 +122,17 @@ importers:
   packages/wallets/aptos:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^1.33.1
-        version: 1.33.1
+        specifier: ^1.35.0
+        version: 1.35.0(axios@1.7.9)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
-        specifier: ^4.23.0
-        version: 4.23.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+        specifier: ^5.0.0
+        version: 5.0.1(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(axios@1.7.9)(got@11.8.6)
       '@aptos-labs/wallet-standard':
-        specifier: ^0.2.0
-        version: 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
-      '@bitget-wallet/aptos-wallet-adapter':
-        specifier: ^0.1.2
-        version: 0.1.2(@aptos-labs/wallet-adapter-core@4.23.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0))(aptos@1.21.0)
-      '@martianwallet/aptos-wallet-adapter':
-        specifier: ^0.0.5
-        version: 0.0.5
-      '@pontem/wallet-adapter-plugin':
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@xlabs-libs/wallet-aggregator-core':
         specifier: workspace:^
         version: link:../core
-      fewcha-plugin-wallet-adapter:
-        specifier: ^0.1.3
-        version: 0.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      petra-plugin-wallet-adapter:
-        specifier: ^0.4.5
-        version: 0.4.5(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0)
     devDependencies:
       '@types/node':
         specifier: ^18.19.69
@@ -563,24 +548,23 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
-  '@aptos-connect/wallet-adapter-plugin@2.3.4':
-    resolution: {integrity: sha512-YTV7pSpzv5tx97G5suMnDplMMQYDM0VfpP1hQjEn8jLkw6I+hNDxRfINL1/k3mp+jm0TmghmNUiFYHFuVSS6wg==}
+  '@aptos-connect/wallet-adapter-plugin@2.4.0':
+    resolution: {integrity: sha512-Vh0cjgzv1lqK5ZxrW87L6w3J7/xk3Trv6ED4YS0qGrEc/TaK2XLOsikJMhUaupKajyLz4O0oS34c2eS2o0cHGQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
-      '@aptos-labs/wallet-standard': ^0.2.0
+      '@aptos-labs/wallet-standard': ^0.3.0
 
-  '@aptos-connect/wallet-api@0.1.6':
-    resolution: {integrity: sha512-S/D95pfDKSEEI8SsYy7sSzrjJ1DDnlVx7JVT9kpW11IjgCpHMHFs62EhZVhxztwcS+CYMyKdQpDyRO+IDtPVFw==}
+  '@aptos-connect/wallet-api@0.1.9':
+    resolution: {integrity: sha512-Olxvg/Jpf426uiEIUbxFuoRluhX3dja9EUqklY29yw/wOY7QDFv0+Es71xp8R2lgaU3gPFJxUwko1Jwz0XjswQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
-      '@aptos-labs/wallet-standard': ^0.2.0
       aptos: ^1.20.0
 
-  '@aptos-connect/web-transport@0.1.1':
-    resolution: {integrity: sha512-QIh4enF0YCYkSBbaoC4k5bQP6z+mcRsNS24oDm4fnCN03bgfrRXr1wAlX4TPoGHnAuIOHgmZqh/xVoaK48bTDg==}
+  '@aptos-connect/web-transport@0.1.3':
+    resolution: {integrity: sha512-XgQqBkXMqTdbD3+udTGpQQtLYyPBzyVGvdOdPi6Yk6/DY61caFryT28e+Ibg3BkPwF6OcfwFf5QkBTaMWFT4LA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
-      '@aptos-labs/wallet-standard': ^0.2.0
+      '@aptos-labs/wallet-standard': ^0.3.0
       '@telegram-apps/bridge': ^1.0.0
       aptos: ^1.20.0
 
@@ -592,27 +576,27 @@ packages:
     resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
     engines: {node: '>=15.10.0'}
 
-  '@aptos-labs/ts-sdk@1.33.1':
-    resolution: {integrity: sha512-d6nWtUI//fyEN8DeLjm3+ro87Ad6+IKwR9pCqfrs/Azahso1xR1Llxd/O6fj/m1DDsuDj/HAsCsy5TC/aKD6Eg==}
-    engines: {node: '>=11.0.0'}
-
-  '@aptos-labs/wallet-adapter-core@2.1.0':
-    resolution: {integrity: sha512-ZSCCsFt2heEh9IDaObbzw8EwqfzJGCWGBoaGouBtOYn2DVkh5R0P9xRj6ryF9cuO+tkfP+8KZmZ9m4c+xsJN2g==}
-
-  '@aptos-labs/wallet-adapter-core@2.2.0':
-    resolution: {integrity: sha512-JL0zTXXoSQba1EDGqY5yTJxZVKMKwgMKZNA1JyV54s5loWzE2tinwg002EB+ONodkVmMhKbWnajCFFOgvgk+NQ==}
-
-  '@aptos-labs/wallet-adapter-core@3.16.0':
-    resolution: {integrity: sha512-4pBNoDLzuIOxdNwJEO770bkxROuEIQis0H0lFOVVCL33jK8/MWLlQo8hFgc71ovN1vWfdERDEgPLbAtVChploQ==}
+  '@aptos-labs/aptos-client@1.0.0':
+    resolution: {integrity: sha512-P/U/xz9w7+tTQDkaeAc693lDFcADO15bjD5RtP/2sa5FSIYbAyGI5A1RfSNPESuBjvskHBa6s47wajgSt4yX7g==}
+    engines: {node: '>=15.10.0'}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.13.2
-      aptos: ^1.21.0
+      axios: ^1.7.7
+      got: ^11.8.6
 
-  '@aptos-labs/wallet-adapter-core@4.23.0':
-    resolution: {integrity: sha512-7QC4Zae9eFmPQpSkhElF69zn5rVpSIoB437yuDktUsZY1C3YFCRHvxkFk7mO0zMdb3ec6NikD62Iag9oFuLKMg==}
+  '@aptos-labs/aptos-dynamic-transaction-composer@0.1.3':
+    resolution: {integrity: sha512-bJl+Zq5QbhpcPIJakAkl9tnT3T02mxCYhZThQDhUmjsOZ5wMRlKJ0P7aaq1dmlybSHkVj7vRgOy2t86/NDKKng==}
+
+  '@aptos-labs/script-composer-pack@0.0.9':
+    resolution: {integrity: sha512-Y3kA1rgF65HETgoTn2omDymsgO+fnZouPLrKJZ9sbxTGdOekIIHtGee3A2gk84eCqa02ZKBumZmP+IDCXRtU/g==}
+
+  '@aptos-labs/ts-sdk@1.35.0':
+    resolution: {integrity: sha512-ChW2Lvi6lKfEb0AYo0HAa98bYf0+935nMdjl40wFMWsR+mxFhtNA4EYINXsHVTMPfE/WV9sXEvDInvscJFrALQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aptos-labs/wallet-adapter-core@5.0.1':
+    resolution: {integrity: sha512-v26HYtxUKiDTjjX29OA7xOFDRYGg/Uu0oxniNJmNllSWghu7WRoIUMeIGPFHyIdS/UEmY85axh5LfA8MYo86vA==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.33.1
-      aptos: ^1.21.0
+      '@aptos-labs/ts-sdk': ^1.35.0
 
   '@aptos-labs/wallet-standard@0.0.11':
     resolution: {integrity: sha512-8dygyPBby7TaMJjUSyeVP4R1WC9D/FPpX9gVMMLaqTKCXrSbkzhGDxcuwbMZ3ziEwRmx3zz+d6BIJbDhd0hm5g==}
@@ -623,8 +607,8 @@ packages:
       '@aptos-labs/ts-sdk': ^1.17.0
       '@wallet-standard/core': ^1.0.3
 
-  '@aptos-labs/wallet-standard@0.2.0':
-    resolution: {integrity: sha512-4aoO4MlqzrW+CtO83MwbHMMtu91DL5B7YKRvhJbRnVB4R+QCOwBI/aQTkNZbKBDfOplLlqWTTl6Li0l6e02YLQ==}
+  '@aptos-labs/wallet-standard@0.3.0':
+    resolution: {integrity: sha512-M0Luh2hWW0BlSHv90YytOJmbE5VeHR/w8ddd7BO8N8jZ2WylKW6AHdkn6oUi1Ft9yb2dt3Qp+T/Sd2JFoRGyzw==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.17.0
       '@wallet-standard/core': ^1.0.3
@@ -682,12 +666,6 @@ packages:
     peerDependencies:
       viem: ^1.19.3
       wagmi: ^1.4.7
-
-  '@bitget-wallet/aptos-wallet-adapter@0.1.2':
-    resolution: {integrity: sha512-6dImtKlwdk0zuYKQpeZ/nOVyyBXqTxVin9ZLgdyPXsnBcpy0PnyGgffsfsOVHxk93eOdiRjNxoiCs1b4a+1ssg==}
-    peerDependencies:
-      '@aptos-labs/wallet-adapter-core': 3.5.0
-      aptos: ^1.21.0
 
   '@blockshake/defly-connect@1.1.1':
     resolution: {integrity: sha512-Ft3/zqnUeV5dmTXIyTB5amyUdwG899NQ9PSVdGf9oNsnq+Q+IJMVo+GjntTC8sC7/z9cDRYJ2xnj3YjCtTfQcg==}
@@ -1022,9 +1000,6 @@ packages:
   '@evanhahn/lottie-web-light@5.8.1':
     resolution: {integrity: sha512-U0G1tt3/UEYnyCNNslWPi1dB7X1xQ9aoSip+B3GTKO/Bns8yz/p39vBkRSN9d25nkbHuCsbjky2coQftj5YVKw==}
 
-  '@fewcha/web3@0.1.38':
-    resolution: {integrity: sha512-t39g9V5zAiYZPGSahp4a0B4WM5IqxQJxr5ednv0f0l5amJZMPyOinFeZDgkLqTIzhe7yq6yIndKbqzPfdu1rng==}
-
   '@fractalwagmi/popup-connection@1.0.18':
     resolution: {integrity: sha512-QcHe8bfeaQAKnFEvnxLqIAD7RFL7Z7bzn0BnOyDJxuj55NFBRVFGmq69MCqn2o6kmmfmusfYSQHNLWiv5L8H5A==}
     peerDependencies:
@@ -1068,11 +1043,11 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
 
-  '@identity-connect/dapp-sdk@0.10.2':
-    resolution: {integrity: sha512-CrREpbz38/JQP7gIkjZbiw5a/71sVkm+4FGb38PWc7GrbDTauPoz96bsN7tbUSpfMlxJhBie+vvhnwL8pT5tRQ==}
+  '@identity-connect/dapp-sdk@0.10.4':
+    resolution: {integrity: sha512-wC1yh0K2EbmIG6oCN7+KRaVXHBUKasuBsm2z/Lq1x5zGJNtFtg6pXQl087ngHixpSCPINx5QqZXd9uXI/oqSmQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
-      '@aptos-labs/wallet-standard': ^0.2.0
+      '@aptos-labs/wallet-standard': ^0.3.0
 
   '@identity-connect/wallet-api@0.1.2':
     resolution: {integrity: sha512-8wyC0rWYb4+L0/K9Kf+LV9U8k5ZUkbauyf4lVVdUatCw1trsBVXObACKzgEidfpfgx23S9w7hctLpegb/QkwSg==}
@@ -1340,9 +1315,6 @@ packages:
   '@lit/reactive-element@1.6.1':
     resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
 
-  '@martianwallet/aptos-wallet-adapter@0.0.5':
-    resolution: {integrity: sha512-x6Q3bM7HSltCAD8Zl0AeU1AFhu0M+Ho22QP+oOXWhdb4TledVVLNfGIAx1jP4slqfcpDGOjnibPtPt8Bm32wmg==}
-
   '@metamask/detect-provider@2.0.0':
     resolution: {integrity: sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==}
     engines: {node: '>=14.0.0'}
@@ -1455,9 +1427,6 @@ packages:
     resolution: {integrity: sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==}
     deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
 
-  '@mysten/bcs@0.3.0':
-    resolution: {integrity: sha512-Me6OkrS+idPq+ZUM1MEcKP9YOTacZKLwo0gf8rfeImQ+G25tqPRhjpccZGOUJGOKh+gojH2vjkWi2TYJv9kNCg==}
-
   '@mysten/bcs@0.7.1':
     resolution: {integrity: sha512-wFPb8bkhwrbiStfZMV5rFM7J+umpke59/dNjDp+UYJKykNlW23LCk2ePyEUvGdb62HGJM1jyOJ8g4egE3OmdKA==}
 
@@ -1469,11 +1438,6 @@ packages:
 
   '@mysten/bcs@0.9.0':
     resolution: {integrity: sha512-h56essa8oSS4/J0Dby8k8stMoOSt+QZIEIeZNtgTOWh9HeV69yFg2BUg/+Rk7jzfWzvUmw9lFyKNipXcD5QOTw==}
-
-  '@mysten/sui.js@0.13.0':
-    resolution: {integrity: sha512-8s4IYN6GH95Begjuy0Xr45vQyyVZZHx83g5hJOpT9o98kQgdjaO218UdqQRVoFt/TODpNsTaI5OlymlKCgFVTQ==}
-    engines: {node: '>=16'}
-    deprecated: This package has been renamed to @mysten/sui, please update to use the renamed package.
 
   '@mysten/sui.js@0.32.2':
     resolution: {integrity: sha512-/Hm4xkGolJhqj8FvQr7QSHDTlxIvL52mtbOao9f75YjrBh7y1Uh9kbJSY7xiTF1NY9sv6p5hUVlYRJuM0Hvn9A==}
@@ -1547,9 +1511,6 @@ packages:
   '@noble/hashes@1.6.1':
     resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@noble/secp256k1@1.7.1':
-    resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1674,9 +1635,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@pontem/wallet-adapter-plugin@0.2.1':
-    resolution: {integrity: sha512-mrhCT+mFsDtjFHZj9LBksY++ciQiAlr+gkHhvEzkuQkYuHkCf6HwKOkIlDL42cl7y8/15NrfZomEQ5Uxudhc3g==}
 
   '@project-serum/sol-wallet-adapter@0.2.0':
     resolution: {integrity: sha512-ed7wZwlDqjF88VCq7eHVO8njHqdUkBxBL8WEVOnB47ooLO4btOJt6GBdkKpKqKX86c86LiEROJclcdW8e7kIjg==}
@@ -2360,9 +2318,6 @@ packages:
 
   '@types/connect@3.4.35':
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -3347,9 +3302,6 @@ packages:
   cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
 
-  cross-fetch@3.2.0:
-    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
-
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -3752,9 +3704,6 @@ packages:
 
   fastq@1.14.0:
     resolution: {integrity: sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==}
-
-  fewcha-plugin-wallet-adapter@0.1.3:
-    resolution: {integrity: sha512-Ek59XhrkjVN+Yj1eBNI/SLGLgo9Sn1LVh8uDKgBaNix7nNAAJrgo2CoPCk/L595TSoO5FJtkBFdlnvRPAGJlAQ==}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -4180,11 +4129,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jayson@3.7.0:
-    resolution: {integrity: sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   jayson@4.1.0:
     resolution: {integrity: sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==}
     engines: {node: '>=8'}
@@ -4433,9 +4377,6 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-
-  lossless-json@1.0.5:
-    resolution: {integrity: sha512-RicKUuLwZVNZ6ZdJHgIZnSeA05p8qWc5NW0uR96mpPIjN9WDLUg9+kj1esQU1GkPn9iLZVKatSQK5gyiaFHgJA==}
 
   lottie-web@5.10.2:
     resolution: {integrity: sha512-d0PFIGiwuMsJYaF4uPo+qG8dEorlI+xFI2zrrFtE1bGO4WoLIz+NjremxEq1swpR7juR10aeOtmNh3d6G3ub0A==}
@@ -4795,12 +4736,6 @@ packages:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
 
-  petra-plugin-wallet-adapter@0.4.5:
-    resolution: {integrity: sha512-x2S2xRAIz/5ytbB2wHCTJhqLBDsgWPEVmj7X2aril1BUplIGPJHTstgo8hqOngb2rtYbBY+wviyS9Di4IDCGRA==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.3.0
-      aptos: ^1.21.0
-
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
@@ -4966,9 +4901,6 @@ packages:
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
-  pump@3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
-
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
@@ -5091,9 +5023,6 @@ packages:
   readable-stream@1.0.34:
     resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==}
 
-  readable-stream@2.3.7:
-    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
-
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -5213,9 +5142,6 @@ packages:
   rlp@2.2.7:
     resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
     hasBin: true
-
-  rpc-websockets@7.11.2:
-    resolution: {integrity: sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==}
 
   rpc-websockets@7.5.1:
     resolution: {integrity: sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==}
@@ -5939,18 +5865,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.2.3:
     resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}
     engines: {node: '>=10.0.0'}
@@ -6094,33 +6008,38 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@aptos-connect/wallet-adapter-plugin@2.3.4(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)':
+  '@aptos-connect/wallet-adapter-plugin@2.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.6(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@identity-connect/dapp-sdk': 0.10.2(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
       - aptos
       - debug
 
-  '@aptos-connect/wallet-api@0.1.6(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@identity-connect/api': 0.7.0
       aptos: 1.21.0
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.1.1(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)':
+  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.6(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@telegram-apps/bridge': 1.7.1
       aptos: 1.21.0
       uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
 
   '@aptos-labs/aptos-cli@1.0.2':
     dependencies:
@@ -6133,10 +6052,22 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@aptos-labs/ts-sdk@1.33.1':
+  '@aptos-labs/aptos-client@1.0.0(axios@1.7.9)(got@11.8.6)':
+    dependencies:
+      axios: 1.7.9
+      got: 11.8.6
+
+  '@aptos-labs/aptos-dynamic-transaction-composer@0.1.3': {}
+
+  '@aptos-labs/script-composer-pack@0.0.9':
+    dependencies:
+      '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
+
+  '@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
-      '@aptos-labs/aptos-client': 0.1.1
+      '@aptos-labs/aptos-client': 1.0.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/script-composer-pack': 0.0.9
       '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1
       '@scure/bip32': 1.6.0
@@ -6147,46 +6078,16 @@ snapshots:
       jwt-decode: 4.0.0
       poseidon-lite: 0.2.1
     transitivePeerDependencies:
-      - debug
+      - axios
+      - got
 
-  '@aptos-labs/wallet-adapter-core@2.1.0':
+  '@aptos-labs/wallet-adapter-core@5.0.1(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)(axios@1.7.9)(got@11.8.6)':
     dependencies:
-      aptos: 1.21.0
-      buffer: 6.0.3
-      eventemitter3: 4.0.7
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/wallet-adapter-core@2.2.0':
-    dependencies:
-      aptos: 1.21.0
-      buffer: 6.0.3
-      eventemitter3: 4.0.7
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/wallet-adapter-core@3.16.0(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0)':
-    dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.0.11
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.33.1)
-      aptos: 1.21.0
-      buffer: 6.0.3
-      eventemitter3: 4.0.7
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/wallet-adapter-core@4.23.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
-    dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.3.4(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.33.1)
-      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)
-      aptos: 1.21.0
+      '@aptos-connect/wallet-adapter-plugin': 2.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(axios@1.7.9)(got@11.8.6)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.7.9)(got@11.8.6)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -6195,32 +6096,37 @@ snapshots:
       - '@mizuwallet-sdk/protocol'
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
+      - aptos
+      - axios
       - debug
+      - got
 
-  '@aptos-labs/wallet-standard@0.0.11':
+  '@aptos-labs/wallet-standard@0.0.11(axios@1.7.9)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       '@wallet-standard/core': 1.0.3
     transitivePeerDependencies:
-      - debug
+      - axios
+      - got
 
-  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)':
+  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       '@wallet-standard/core': 1.0.3
 
-  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)':
+  '@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       '@wallet-standard/core': 1.0.3
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.33.1)':
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(axios@1.7.9)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.0.11
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.0.11(axios@1.7.9)(got@11.8.6)
       '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
-      - debug
+      - axios
+      - got
 
   '@atomrigslab/dekey-web-wallet-provider@1.2.1':
     dependencies:
@@ -6350,11 +6256,6 @@ snapshots:
       - encoding
       - ts-node
       - utf-8-validate
-
-  '@bitget-wallet/aptos-wallet-adapter@0.1.2(@aptos-labs/wallet-adapter-core@4.23.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0))(aptos@1.21.0)':
-    dependencies:
-      '@aptos-labs/wallet-adapter-core': 4.23.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
-      aptos: 1.21.0
 
   '@blockshake/defly-connect@1.1.1(algosdk@1.24.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
@@ -7215,17 +7116,6 @@ snapshots:
 
   '@evanhahn/lottie-web-light@5.8.1': {}
 
-  '@fewcha/web3@0.1.38(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@mysten/sui.js': 0.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      aptos: 1.21.0
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - utf-8-validate
-
   '@fractalwagmi/popup-connection@1.0.18(react-dom@16.13.1(react@16.13.1))(react@16.13.1)':
     dependencies:
       react: 16.13.1
@@ -7265,36 +7155,37 @@ snapshots:
 
   '@identity-connect/api@0.7.0': {}
 
-  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)':
+  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.6(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       '@noble/hashes': 1.6.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
     transitivePeerDependencies:
-      - '@aptos-labs/wallet-standard'
+      - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/dapp-sdk@0.10.2(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)':
+  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.6(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@aptos-connect/web-transport': 0.1.1(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3))(@telegram-apps/bridge@1.7.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3))(aptos@1.21.0)
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0)
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(aptos@1.21.0)
       axios: 1.7.9
       uuid: 9.0.1
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
       - aptos
       - debug
 
-  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0)':
+  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(aptos@1.21.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       aptos: 1.21.0
 
   '@improbable-eng/grpc-web@0.14.1(google-protobuf@3.21.2)':
@@ -7783,7 +7674,7 @@ snapshots:
       bech32: 1.1.4
       buffer: 6.0.3
       long: 4.0.0
-      protobufjs: 6.11.3
+      protobufjs: 6.11.4
     transitivePeerDependencies:
       - debug
 
@@ -7801,7 +7692,7 @@ snapshots:
   '@keplr-wallet/proto-types@0.11.59':
     dependencies:
       long: 4.0.0
-      protobufjs: 6.11.3
+      protobufjs: 6.11.4
 
   '@keplr-wallet/types@0.11.59':
     dependencies:
@@ -7898,7 +7789,7 @@ snapshots:
       '@ledgerhq/errors': 6.16.0
       '@ledgerhq/logs': 6.12.0
       '@ledgerhq/types-live': 6.43.0
-      axios: 1.6.2
+      axios: 1.7.9
       eip55: 2.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7930,7 +7821,7 @@ snapshots:
       '@ledgerhq/hw-transport': 6.28.3
       '@ledgerhq/hw-transport-mocker': 6.28.0
       '@ledgerhq/logs': 6.10.1
-      axios: 1.6.2
+      axios: 1.7.9
       bignumber.js: 9.1.1
       crypto-js: 4.1.1
     transitivePeerDependencies:
@@ -8027,13 +7918,6 @@ snapshots:
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.0.0
 
-  '@martianwallet/aptos-wallet-adapter@0.0.5':
-    dependencies:
-      '@aptos-labs/wallet-adapter-core': 2.1.0
-      aptos: 1.21.0
-    transitivePeerDependencies:
-      - debug
-
   '@metamask/detect-provider@2.0.0': {}
 
   '@metamask/eth-sig-util@4.0.1':
@@ -8056,7 +7940,7 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
 
   '@metamask/obs-store@7.0.0':
     dependencies:
@@ -8114,20 +7998,21 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)':
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.0.3)(axios@1.7.9)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.33.1)(@wallet-standard/core@1.0.3)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0))
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.0.3)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0))
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
     transitivePeerDependencies:
       - '@wallet-standard/core'
-      - debug
+      - axios
+      - got
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.6.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.1.2(graphql@16.6.0)
@@ -8229,10 +8114,6 @@ snapshots:
       '@motionone/dom': 10.16.4
       tslib: 2.5.0
 
-  '@mysten/bcs@0.3.0':
-    dependencies:
-      bn.js: 5.2.1
-
   '@mysten/bcs@0.7.1':
     dependencies:
       bs58: 5.0.0
@@ -8248,26 +8129,6 @@ snapshots:
   '@mysten/bcs@0.9.0':
     dependencies:
       bs58: 5.0.0
-
-  '@mysten/sui.js@0.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@mysten/bcs': 0.3.0
-      '@noble/hashes': 1.6.1
-      '@noble/secp256k1': 1.7.1
-      '@scure/bip32': 1.6.0
-      '@scure/bip39': 1.5.0
-      bn.js: 5.2.1
-      buffer: 6.0.3
-      cross-fetch: 3.2.0
-      jayson: 3.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      js-sha3: 0.8.0
-      lossless-json: 1.0.5
-      rpc-websockets: 7.11.2
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - utf-8-validate
 
   '@mysten/sui.js@0.32.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
@@ -8288,10 +8149,10 @@ snapshots:
   '@mysten/sui.js@0.40.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@mysten/bcs': 0.7.3
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1
       '@open-rpc/client-js': 1.8.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@scure/bip32': 1.3.2
+      '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
       '@suchipi/femver': 1.0.0
       events: 3.3.0
@@ -8305,10 +8166,10 @@ snapshots:
   '@mysten/sui.js@0.42.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@mysten/bcs': 0.7.4
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1
       '@open-rpc/client-js': 1.8.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@scure/bip32': 1.3.2
+      '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
       '@suchipi/femver': 1.0.0
       events: 3.3.0
@@ -8322,9 +8183,9 @@ snapshots:
   '@mysten/sui.js@0.48.0':
     dependencies:
       '@mysten/bcs': 0.9.0
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1
-      '@scure/bip32': 1.3.2
+      '@scure/bip32': 1.6.0
       '@scure/bip39': 1.5.0
       '@suchipi/femver': 1.0.0
       superstruct: 1.0.3
@@ -8407,8 +8268,6 @@ snapshots:
   '@noble/hashes@1.6.0': {}
 
   '@noble/hashes@1.6.1': {}
-
-  '@noble/secp256k1@1.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8545,13 +8404,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pontem/wallet-adapter-plugin@0.2.1':
-    dependencies:
-      '@aptos-labs/wallet-adapter-core': 2.2.0
-      aptos: 1.21.0
-    transitivePeerDependencies:
-      - debug
-
   '@project-serum/sol-wallet-adapter@0.2.0(@solana/web3.js@1.87.6(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/web3.js': 1.87.6(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -8620,7 +8472,7 @@ snapshots:
   '@scure/bip32@1.3.0':
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.1
 
   '@scure/bip32@1.3.2':
@@ -8637,7 +8489,7 @@ snapshots:
 
   '@scure/bip39@1.2.0':
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.1
 
   '@scure/bip39@1.2.1':
@@ -9069,7 +8921,7 @@ snapshots:
 
   '@solana/wallet-standard-util@1.1.0':
     dependencies:
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.7.0
       '@solana/wallet-standard-chains': 1.1.0
       '@solana/wallet-standard-features': 1.1.0
 
@@ -9438,7 +9290,7 @@ snapshots:
       events: 3.3.0
       fast-safe-stringify: 2.1.1
       once: 1.4.0
-      pump: 3.0.0
+      pump: 3.0.2
       readable-stream: 3.6.2
 
   '@toruslabs/openlogin-jrpc@3.2.0(@babel/runtime@7.20.13)':
@@ -9450,7 +9302,7 @@ snapshots:
       events: 3.3.0
       fast-safe-stringify: 2.1.1
       once: 1.4.0
-      pump: 3.0.0
+      pump: 3.0.2
       readable-stream: 3.6.2
 
   '@toruslabs/openlogin-utils@2.1.0(@babel/runtime@7.20.13)':
@@ -9479,7 +9331,7 @@ snapshots:
       is-stream: 2.0.1
       lodash-es: 4.17.21
       loglevel: 1.8.1
-      pump: 3.0.0
+      pump: 3.0.2
     transitivePeerDependencies:
       - '@sentry/types'
       - bufferutil
@@ -9502,7 +9354,7 @@ snapshots:
       lodash.merge: 4.6.2
       loglevel: 1.8.1
       once: 1.4.0
-      pump: 3.0.0
+      pump: 3.0.2
     transitivePeerDependencies:
       - '@sentry/types'
 
@@ -9626,10 +9478,6 @@ snapshots:
   '@types/connect@3.4.35':
     dependencies:
       '@types/node': 18.11.11
-
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 18.19.69
 
   '@types/debug@4.1.12':
     dependencies:
@@ -11255,12 +11103,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  cross-fetch@3.2.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -11830,17 +11672,6 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fewcha-plugin-wallet-adapter@0.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    dependencies:
-      '@aptos-labs/wallet-adapter-core': 2.2.0
-      '@fewcha/web3': 0.1.38(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      aptos: 1.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - utf-8-validate
-
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.0.4
@@ -12248,10 +12079,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   isomorphic-ws@4.0.1(ws@7.5.9(bufferutil@4.0.7)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 7.5.9(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -12273,25 +12100,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jayson@3.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 12.20.55
-      '@types/ws': 7.4.7
-      JSONStream: 1.3.5
-      commander: 2.20.3
-      delay: 5.0.0
-      es6-promisify: 5.0.0
-      eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   jayson@4.1.0(bufferutil@4.0.7)(utf-8-validate@5.0.10):
     dependencies:
@@ -12375,7 +12183,7 @@ snapshots:
     dependencies:
       '@metamask/safe-event-emitter': 3.0.0
       json-rpc-engine: 6.1.0
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
 
   json-rpc-random-id@1.0.1: {}
 
@@ -12580,8 +12388,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  lossless-json@1.0.5: {}
 
   lottie-web@5.10.2: {}
 
@@ -12903,14 +12709,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  petra-plugin-wallet-adapter@0.4.5(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0):
-    dependencies:
-      '@aptos-labs/ts-sdk': 1.33.1
-      '@aptos-labs/wallet-adapter-core': 3.16.0(@aptos-labs/ts-sdk@1.33.1)(aptos@1.21.0)
-      aptos: 1.21.0
-    transitivePeerDependencies:
-      - debug
-
   picocolors@1.1.0: {}
 
   picomatch@2.3.1: {}
@@ -13106,11 +12904,6 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
-  pump@3.0.0:
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -13262,16 +13055,6 @@ snapshots:
       isarray: 0.0.1
       string_decoder: 0.10.31
 
-  readable-stream@2.3.7:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -13412,15 +13195,6 @@ snapshots:
   rlp@2.2.7:
     dependencies:
       bn.js: 5.2.1
-
-  rpc-websockets@7.11.2:
-    dependencies:
-      eventemitter3: 4.0.7
-      uuid: 8.3.2
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
 
   rpc-websockets@7.5.1:
     dependencies:
@@ -13795,7 +13569,7 @@ snapshots:
 
   through2@2.0.5:
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       xtend: 4.0.2
 
   through@2.3.8: {}
@@ -14153,11 +13927,6 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
-
-  ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10


### PR DESCRIPTION
Aptos Wallet Adapter has been major upgraded to support only wallets that follow the official Apos wallet standard, see https://github.com/aptos-labs/aptos-wallet-adapter/pull/464

This PR updates the `@xlabs-libs/wallet-aggregator-aptos` to be up to date with the latest Aptos wallet adapter, as well as bumps other Aptos dependencies versions.

This is important because
- We want to make sure users are not interacting with out-of-date and unmaintained wallets
- Get new features and updates coming to the Aptos Wallet Adapter
-  Better handling of the types coming from the wallet for a better dev exp.

You can see latest version deployed here https://aptos-labs.github.io/aptos-wallet-adapter/

Note: looks like the `@xlabs-libs/wallet-aggregator-aptos` does not follow semver? I'd assume this type of change requires a major bump, but will be happy to bump to whatever you think makes sense.